### PR TITLE
crypto: poseidon2: Add helpers for round constants and internal MDS

### DIFF
--- a/src/crypto/poseidon2/roundUtils.huff
+++ b/src/crypto/poseidon2/roundUtils.huff
@@ -2,6 +2,8 @@
 
 /// @dev The scalar field modulus of BN254
 #define constant PRIME = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001 
+/// @dev The width of the poseidon sponge
+#define constant WIDTH = 0x3
 
 /// @dev Push the prime onto the stack
 #define macro PUSH_PRIME() = {
@@ -33,4 +35,34 @@
     
     // Compute x^5 (mod p)
     mulmod          // [x^5 mod p]
+}
+
+/// @dev Apply the internal MDS matrix to the sponge state
+/// For t = 3, this is the matrix:
+///     [2, 1, 1]
+///     [1, 2, 1]
+///     [1, 1, 3]
+///
+/// This can be done efficiently by adding the sum to each element as in the
+/// external MDS case but adding an additional copy of the final state
+/// element
+/// @param Takes [state[0], state[1], state[2]]
+/// @return [state'[0], state'[1], state'[2]]
+#define macro INTERNAL_MDS() = takes(3) returns(7) {
+    // Takes [state[0], state[1], state[2]]
+    PUSH_PRIME()            // [PRIME, state[0], state[1], state[2]]
+    dup4 dup4 dup4          // [state[0], state[1], state[2], PRIME, state[0], state[1], state[2]]
+
+    // Compute the sum of the elements (mod p)
+    PUSH_PRIME() swap2      // [state[1], state[0], PRIME, state[2], PRIME, state[0], state[1], state[2]]
+    addmod                  // [state[0] + state[1] mod p, state[2], PRIME, state[0], state[1], state[2]]
+    addmod                  // [sum, state[0], state[1], state[2]]
+
+    // Add the sum to each element
+    PUSH_PRIME() dup2       // [sum, PRIME, sum, state[0], state[1], state[2]] 
+    dup6 addmod             // [state[2] + sum, sum, state[0], state[1], state[2]] 
+    PUSH_PRIME() dup3       // [sum, PRIME, state[2] + sum, sum, state[0], state[1], state[2]]
+    dup6 addmod             // [state[1] + sum, state[2] + sum, sum, state[0], state[1], state[2]]
+    PUSH_PRIME() dup4       // [sum, PRIME, state[1] + sum, state[2] + sum, sum, state[0], state[1], state[2]]
+    dup6 addmod             // [state[0] + sum, state[1] + sum, state[2] + sum, sum, state[0], state[1], state[2]]
 }

--- a/test/Poseidon.t.sol
+++ b/test/Poseidon.t.sol
@@ -38,9 +38,31 @@ contract PoseidonTest is Test {
         uint256 expected = addmod(testValue, TEST_RC, PRIME);
         assertEq(result, expected, "Expected result to match x + RC mod p");
     }
+
+    /// @dev Test the internal MDS function applied to a single input
+    /// The internal MDS adds the sum of the elements to each element
+    function testInternalMds() public {
+        uint256 a = vm.randomUint();
+        uint256 b = vm.randomUint();
+        uint256 c = vm.randomUint();
+        (uint256 a1, uint256 b1, uint256 c1) = poseidonSuite.testInternalMds(a, b, c);
+
+        // Calculate the sum of the elements
+        uint256 sum = addmod(a, b, PRIME);
+        sum = addmod(sum, c, PRIME);
+
+        // Calculate the expected results
+        uint256 expectedA = addmod(a, sum, PRIME);
+        uint256 expectedB = addmod(b, sum, PRIME);
+        uint256 expectedC = addmod(c, sum, PRIME);
+        assertEq(a1, expectedA, "Expected result to match a + sum mod p");
+        assertEq(b1, expectedB, "Expected result to match b + sum mod p");
+        assertEq(c1, expectedC, "Expected result to match c + sum mod p");
+    }
 }
 
 interface PoseidonSuite {
     function testSboxSingle(uint256) external returns (uint256);
     function testAddRc(uint256) external returns (uint256);
+    function testInternalMds(uint256, uint256, uint256) external returns (uint256, uint256, uint256);
 }

--- a/test/huff/testPoseidonUtils.huff
+++ b/test/huff/testPoseidonUtils.huff
@@ -8,6 +8,8 @@
 #define function testSboxSingle(uint256) nonpayable returns(uint256) 
 /// @dev Test the ADD_RC function applied to a single input
 #define function testAddRc(uint256) nonpayable returns(uint256) 
+/// @dev Test the internal MDS function applied to a single input
+#define function testInternalMds(uint256, uint256, uint256) nonpayable returns(uint256, uint256, uint256)
 
 /// @dev The test round constant
 #define constant TEST_RC = 0x1337
@@ -18,6 +20,7 @@
     0x0 calldataload 0xe0 shr // [SELECTOR]
     dup1 __FUNC_SIG(testSboxSingle)     eq testSboxSingle   jumpi
     dup1 __FUNC_SIG(testAddRc)          eq testAddRc        jumpi
+    dup1 __FUNC_SIG(testInternalMds)    eq testInternalMds  jumpi
 
     // Revert if the function selector is not valid
     0x1 0x0 mstore
@@ -27,6 +30,8 @@
         TEST_SBOX_SINGLE()
     testAddRc:
         TEST_ADD_RC()
+    testInternalMds:
+        TEST_INTERNAL_MDS()
 }
 
 /// @notice Test the sbox function applied to a single input
@@ -55,10 +60,36 @@
     RETURN_FIRST()
 }
 
+/// @notice Test the internal MDS function applied to a single input
+#define macro TEST_INTERNAL_MDS() = takes(0) returns(0) {
+    // Get the input from calldata 
+    PUSH_PRIME()
+    0x44 calldataload
+    0x24 calldataload
+    0x04 calldataload               // [state[0], state[1], state[2], PRIME]
+
+    // Call the internal MDS function
+    INTERNAL_MDS()
+
+    // Return the result
+    RETURN_FIRST_THREE()
+}
+
 // --- Helpers --- //
 
 /// @dev Return the first value on the stack
 #define macro RETURN_FIRST() = returns(0) {
     0x00 mstore
     0x20 0x00 return
+}
+
+/// @dev Return the first three values on the stack
+#define macro RETURN_FIRST_THREE() = returns(0) {
+    // Store the values
+    0x00 mstore
+    0x20 mstore
+    0x40 mstore
+
+    // Return the values
+    0x60 0x00 return
 }


### PR DESCRIPTION
### Purpose
This PR adds huff implementations for the internal MDS matrix multiplication and the single-element round constants.

### Testing
- [x] All unit tests pass