### PR TITLE
crypto: poseidon2: Implement external MDS matrix multiplication

### DIFF
--- a/src/crypto/poseidon2/roundUtils.huff
+++ b/src/crypto/poseidon2/roundUtils.huff
@@ -3,10 +3,7 @@
 /// @dev The scalar field modulus of BN254
 #define constant PRIME = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001 
 
-/// @dev Push the prime onto the stack
-#define macro PUSH_PRIME() = {
-    [PRIME]
-}
+// --- Core Permutation Methods --- //
 
 /// @dev Add the round constant to the element on top of the stack
 #define macro ADD_RC(RC) = takes(2) returns(1) {
@@ -48,13 +45,7 @@
 /// @return [state'[0], state'[1], state'[2]]
 #define macro INTERNAL_MDS() = takes(3) returns(7) {
     // Takes [state[0], state[1], state[2]]
-    PUSH_PRIME()            // [PRIME, state[0], state[1], state[2]]
-    dup4 dup4 dup4          // [state[0], state[1], state[2], PRIME, state[0], state[1], state[2]]
-
-    // Compute the sum of the elements (mod p)
-    PUSH_PRIME() swap2      // [state[1], state[0], PRIME, state[2], PRIME, state[0], state[1], state[2]]
-    addmod                  // [state[0] + state[1] mod p, state[2], PRIME, state[0], state[1], state[2]]
-    addmod                  // [sum, state[0], state[1], state[2]]
+    SUM_FIRST_THREE()                   // [sum, state[0], state[1], state[2]]
 
     // Double the last state element and add the sum to each element
     PUSH_PRIME() dup2 PUSH_PRIME()      // [PRIME, sum, PRIME, sum, state[0], state[1], state[2]] 
@@ -64,4 +55,45 @@
     dup6 addmod                         // [state'[1], state'[2], sum, state[0], state[1], state[2]]
     PUSH_PRIME() dup4                   // [sum, PRIME, state'[1], state'[2], sum, state[0], state[1], state[2]]
     dup6 addmod                         // [state'[0], state'[1], state'[2], sum, state[0], state[1], state[2]]
+}
+
+/// @dev Apply the external MDS matrix to the sponge state
+/// For t = 3, this is the circulant matrix `circ(2, 1, 1)`
+///
+/// This is equivalent to doubling each element then adding the other two to
+/// it, or more efficiently: adding the sum of the elements to each
+/// individual element. This efficient structure is borrowed from:
+///     https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2.rs#L129-L137
+/// @param Takes [state[0], state[1], state[2]]
+/// @return [state'[0], state'[1], state'[2]]
+#define macro EXTERNAL_MDS() = takes(3) returns(7) {
+    // Takes [state[0], state[1], state[2]]
+    SUM_FIRST_THREE()               // [sum, state[0], state[1], state[2]]
+
+    // Add the sum to each element
+    PUSH_PRIME() dup2               // [sum, PRIME, sum, state[0], state[1], state[2]] 
+    dup6 addmod                     // [state'[2], sum, state[0], state[1], state[2]] 
+    PUSH_PRIME() dup3               // [sum, PRIME, state'[2], sum, state[0], state[1], state[2]]
+    dup6 addmod                     // [state'[1], state'[2], sum, state[0], state[1], state[2]]
+    PUSH_PRIME() dup4               // [sum, PRIME, state'[1], state'[2], sum, state[0], state[1], state[2]]
+    dup6 addmod                     // [state'[0], state'[1], state'[2], sum, state[0], state[1], state[2]]
+}
+
+// --- Helper Macros --- //
+
+/// @dev Push the prime onto the stack
+#define macro PUSH_PRIME() = {
+    [PRIME]
+}
+
+/// @dev Sum the first three elements of the stack modulo the prime
+#define macro SUM_FIRST_THREE() = takes(0) returns(1) {
+    // Takes [a, b, c]
+    PUSH_PRIME()            // [PRIME, a, b, c]
+    dup4 dup4 dup4          // [a, b, c, PRIME, a, b, c]
+
+    // Compute the sum of the elements (mod p)
+    PUSH_PRIME() swap2      // [b, a, PRIME, c, PRIME, a, b, c]
+    addmod                  // [a + b mod p, c, PRIME, a, b, c]
+    addmod                  // [sum, a, b, c]
 }

--- a/test/Poseidon.t.sol
+++ b/test/Poseidon.t.sol
@@ -59,10 +59,31 @@ contract PoseidonTest is Test {
         assertEq(b1, expectedB, "Expected result to match b + sum mod p");
         assertEq(c1, expectedC, "Expected result to match c + sum mod p");
     }
+
+    /// @dev Test the external MDS function applied to a trio of inputs
+    function testExternalMds() public {
+        uint256 a = vm.randomUint();
+        uint256 b = vm.randomUint();
+        uint256 c = vm.randomUint();
+        (uint256 a1, uint256 b1, uint256 c1) = poseidonSuite.testExternalMds(a, b, c);
+
+        // Calculate the sum of the elements
+        uint256 sum = addmod(a, b, PRIME);
+        sum = addmod(sum, c, PRIME);
+
+        // Calculate the expected results
+        uint256 expectedA = addmod(a, sum, PRIME);
+        uint256 expectedB = addmod(b, sum, PRIME);
+        uint256 expectedC = addmod(c, sum, PRIME);
+        assertEq(a1, expectedA, "Expected result to match a + sum mod p");
+        assertEq(b1, expectedB, "Expected result to match b + sum mod p");
+        assertEq(c1, expectedC, "Expected result to match c + sum mod p");
+    }
 }
 
 interface PoseidonSuite {
     function testSboxSingle(uint256) external returns (uint256);
     function testAddRc(uint256) external returns (uint256);
     function testInternalMds(uint256, uint256, uint256) external returns (uint256, uint256, uint256);
+    function testExternalMds(uint256, uint256, uint256) external returns (uint256, uint256, uint256);
 }

--- a/test/huff/testPoseidonUtils.huff
+++ b/test/huff/testPoseidonUtils.huff
@@ -8,8 +8,10 @@
 #define function testSboxSingle(uint256) nonpayable returns(uint256) 
 /// @dev Test the ADD_RC function applied to a single input
 #define function testAddRc(uint256) nonpayable returns(uint256) 
-/// @dev Test the internal MDS function applied to a single input
+/// @dev Test the internal MDS function applied to a trio of inputs
 #define function testInternalMds(uint256, uint256, uint256) nonpayable returns(uint256, uint256, uint256)
+/// @dev Test the external MDS function applied to a trio of inputs
+#define function testExternalMds(uint256, uint256, uint256) nonpayable returns(uint256, uint256, uint256) 
 
 /// @dev The test round constant
 #define constant TEST_RC = 0x1337
@@ -21,6 +23,7 @@
     dup1 __FUNC_SIG(testSboxSingle)     eq testSboxSingle   jumpi
     dup1 __FUNC_SIG(testAddRc)          eq testAddRc        jumpi
     dup1 __FUNC_SIG(testInternalMds)    eq testInternalMds  jumpi
+    dup1 __FUNC_SIG(testExternalMds)    eq testExternalMds  jumpi
 
     // Revert if the function selector is not valid
     0x1 0x0 mstore
@@ -32,7 +35,11 @@
         TEST_ADD_RC()
     testInternalMds:
         TEST_INTERNAL_MDS()
+    testExternalMds:
+        TEST_EXTERNAL_MDS()
 }
+
+// --- Test Cases --- //
 
 /// @notice Test the sbox function applied to a single input
 #define macro TEST_SBOX_SINGLE() = takes(0) returns(0) {
@@ -60,7 +67,7 @@
     RETURN_FIRST()
 }
 
-/// @notice Test the internal MDS function applied to a single input
+/// @notice Test the internal MDS function applied to a trio of inputs
 #define macro TEST_INTERNAL_MDS() = takes(0) returns(0) {
     // Get the input from calldata 
     PUSH_PRIME()
@@ -70,6 +77,21 @@
 
     // Call the internal MDS function
     INTERNAL_MDS()
+
+    // Return the result
+    RETURN_FIRST_THREE()
+}
+
+/// @notice Test the external MDS function applied to a trio of inputs
+#define macro TEST_EXTERNAL_MDS() = takes(0) returns(0) {
+    // Get the input from calldata 
+    PUSH_PRIME()
+    0x44 calldataload
+    0x24 calldataload
+    0x04 calldataload               // [state[0], state[1], state[2], PRIME]
+
+    // Call the internal MDS function
+    EXTERNAL_MDS()
 
     // Return the result
     RETURN_FIRST_THREE()


### PR DESCRIPTION
### Purpose
This PR implements external MDS matrix multiplication for the poseidon helpers.

### Testing
- [x] All unit tests pass