### PR TITLE
rust-reference-impls: verifier: Implement reference prover + vkeys

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,3 +5,16 @@ src = "src"
 out = "out"
 libs = ["lib"]
 remappings = ["forge-std/=lib/forge-std/src/"]
+via_ir = true
+optimizer = true
+optimizer_runs = 200
+
+[fmt]
+line_length = 120
+tab_width = 4
+bracket_spacing = true
+int_types = "long"
+multiline_func_header = "all"
+quote_style = "double"
+number_underscore = "thousands"
+wrap_comments = true

--- a/test/Verifier.t.sol
+++ b/test/Verifier.t.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
-import {BN254} from "solidity-bn254/BN254.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
 
-import {TestUtils} from "./utils/TestUtils.sol";
-import {Verifier} from "../src/verifier/Verifier.sol";
-import {PlonkProof, NUM_WIRE_TYPES, NUM_SELECTORS, VerificationKey} from "../src/verifier/Types.sol";
+import { TestUtils } from "./utils/TestUtils.sol";
+import { Verifier } from "../src/verifier/Verifier.sol";
+import { PlonkProof, NUM_WIRE_TYPES, NUM_SELECTORS, VerificationKey } from "../src/verifier/Types.sol";
 
 contract VerifierTest is TestUtils {
     Verifier public verifier;
@@ -54,7 +54,7 @@ contract VerifierTest is TestUtils {
     function testMalformedProof() public {
         // Create a valid scalar and EC point to use as a base
         BN254.G1Point memory validPoint = BN254.P1();
-        BN254.G1Point memory invalidPoint = BN254.G1Point({x: BN254.BaseField.wrap(42), y: BN254.BaseField.wrap(0)});
+        BN254.G1Point memory invalidPoint = BN254.G1Point({ x: BN254.BaseField.wrap(42), y: BN254.BaseField.wrap(0) });
         BN254.ScalarField validScalar = BN254.ScalarField.wrap(1);
         BN254.ScalarField invalidScalar = BN254.ScalarField.wrap(BN254.R_MOD);
 
@@ -244,5 +244,89 @@ contract VerifierTest is TestUtils {
 
         // This should not revert since we're using valid inputs
         verifier.verify(proof, publicInputs, vk);
+    }
+
+    /// @notice Test the verifier against a reference implementation
+    function testVerifierAgainstReferenceImpl() public {
+        // First compile the binary
+        compileRustBinary("test/rust-reference-impls/verifier/Cargo.toml");
+
+        // Run the reference implementation to generate a proof
+        string[] memory args = new string[](6);
+        args[0] = "./test/rust-reference-impls/target/debug/verifier";
+        args[1] = "mul-two";
+        args[2] = "prove";
+        args[3] = "2"; // a
+        args[4] = "3"; // b
+        args[5] = "6"; // c = a * b
+
+        // The Rust binary will output a single hex string prefixed with "RES:"
+        string memory response = runBinaryGetResponse(args);
+
+        // Split the response to get the proof
+        string[] memory parts = vm.split(response, "RES:");
+        require(parts.length == 2, "Invalid output format");
+
+        // Decode the proof
+        PlonkProof memory proof = abi.decode(vm.parseBytes(parts[1]), (PlonkProof));
+
+        // Create a mock verification key
+        VerificationKey memory vk = createMockVerificationKey();
+
+        // Create the public inputs
+        BN254.ScalarField[] memory publicInputs = new BN254.ScalarField[](1);
+        publicInputs[0] = BN254.ScalarField.wrap(6); // c = a * b = 2 * 3 = 6
+
+        // Print proof structure details
+        console2.log("\nProof structure:");
+        console2.log("wire_comms length: %d", proof.wire_comms.length);
+        console2.log("quotient_comms length: %d", proof.quotient_comms.length);
+        console2.log("wire_evals length: %d", proof.wire_evals.length);
+        console2.log("sigma_evals length: %d", proof.sigma_evals.length);
+
+        // Print wire commitments
+        console2.log("\nWire commitments:");
+        for (uint256 i = 0; i < proof.wire_comms.length; i++) {
+            console2.log("wire_comms[%d].x: %d", i, BN254.BaseField.unwrap(proof.wire_comms[i].x));
+            console2.log("wire_comms[%d].y: %d", i, BN254.BaseField.unwrap(proof.wire_comms[i].y));
+        }
+
+        // Print wire evaluations
+        console2.log("\nWire evaluations:");
+        for (uint256 i = 0; i < proof.wire_evals.length; i++) {
+            console2.log("wire_evals[%d]: %d", i, BN254.ScalarField.unwrap(proof.wire_evals[i]));
+        }
+
+        // Print sigma evaluations
+        console2.log("\nSigma evaluations:");
+        for (uint256 i = 0; i < proof.sigma_evals.length; i++) {
+            console2.log("sigma_evals[%d]: %d", i, BN254.ScalarField.unwrap(proof.sigma_evals[i]));
+        }
+
+        // Print verification key details
+        console2.log("\nVerification key details:");
+        console2.log("n: %d", vk.n);
+        console2.log("l: %d", vk.l);
+        for (uint256 i = 0; i < vk.k.length; i++) {
+            console2.log("k[%d]: %d", i, BN254.ScalarField.unwrap(vk.k[i]));
+        }
+
+        // Print public inputs
+        console2.log("\nPublic inputs:");
+        for (uint256 i = 0; i < publicInputs.length; i++) {
+            console2.log("publicInputs[%d]: %d", i, BN254.ScalarField.unwrap(publicInputs[i]));
+        }
+
+        // Try to verify the proof
+        try verifier.verify(proof, publicInputs, vk) returns (bool result) {
+            console2.log("\nVerification result: %s", result ? "success" : "failure");
+            require(result, "Proof verification failed");
+        } catch Error(string memory reason) {
+            console2.log("\nVerification failed with reason: %s", reason);
+            revert(reason);
+        } catch (bytes memory) {
+            console2.log("\nVerification failed with no reason");
+            revert("Verification failed with no reason");
+        }
     }
 }

--- a/test/rust-reference-impls/Cargo.toml
+++ b/test/rust-reference-impls/Cargo.toml
@@ -1,11 +1,14 @@
 [workspace]
-members = ["merkle", "poseidon", "transcript"]
+members = ["merkle", "poseidon", "transcript", "verifier"]
 
 [workspace.dependencies]
 # === Renegade Dependencies === #
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", default-features = false }
 renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
 mpc-plonk = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
+mpc-relation = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
 
 # === Misc Dependencies === #
 num-bigint = "0.4"

--- a/test/rust-reference-impls/verifier/Cargo.toml
+++ b/test/rust-reference-impls/verifier/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "verifier"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# === Arkworks === #
+ark-bn254 = "0.4.0"
+ark-ff = "0.4.0"
+ark-ec = "0.4.0"
+ark-serialize = "0.4.0"
+
+# === Renegade === #
+renegade-circuit-types = { workspace = true }
+renegade-circuits = { workspace = true }
+renegade-constants = { workspace = true }
+mpc-plonk = { workspace = true }
+mpc-relation = { workspace = true }
+
+# === Misc === #
+clap = { version = "4.4.18", features = ["derive"] }
+ethabi = "18.0.0"
+hex = "0.4.3"
+itertools = "0.14"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/test/rust-reference-impls/verifier/src/main.rs
+++ b/test/rust-reference-impls/verifier/src/main.rs
@@ -1,0 +1,190 @@
+mod mul_two;
+mod sum_pow;
+mod types;
+
+use ark_bn254::Fr;
+use ark_ff::{BigInteger, PrimeField};
+use clap::{Parser, Subcommand};
+use ethabi::{encode, Token};
+use itertools::Itertools;
+use renegade_constants::Scalar;
+use types::*;
+
+// -------
+// | CLI |
+// -------
+
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about = "Reference implementation for PLONK circuit verification"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Multiply two witness values and constrain their product to a public input
+    MulTwo {
+        #[command(subcommand)]
+        action: MulTwoAction,
+    },
+    /// Compute (x₁ + x₂ + ... + xₙ)^5
+    SumPow {
+        #[command(subcommand)]
+        action: SumPowAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum MulTwoAction {
+    /// Print the verification key for the mul-two circuit
+    PrintVkey,
+    /// Generate a proof for the mul-two circuit
+    Prove {
+        /// First witness value (as hex string)
+        a: String,
+        /// Second witness value (as hex string)
+        b: String,
+        /// Expected product (as hex string)
+        c: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum SumPowAction {
+    /// Print the verification key for the sum-pow circuit
+    PrintVkey,
+    /// Generate a proof for the sum-pow circuit
+    Prove {
+        /// Input values to sum and raise to the fifth power (as hex strings)
+        #[arg(required = true, num_args = 10)]
+        inputs: Vec<String>,
+        /// Expected result of (sum)^5 (as hex string)
+        expected: String,
+    },
+}
+
+// --------------
+// | Entrypoint |
+// --------------
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::MulTwo { action } => match action {
+            MulTwoAction::PrintVkey => {
+                let vk = mul_two::generate_verification_key();
+                let vk_token = encode_verification_key(&vk);
+                let encoded = encode(&[vk_token]);
+                println!("RES:{}", hex::encode(encoded));
+            }
+            MulTwoAction::Prove { a, b, c } => {
+                let a = Scalar::from_hex_string(&a).unwrap();
+                let b = Scalar::from_hex_string(&b).unwrap();
+                let c = Scalar::from_hex_string(&c).unwrap();
+                let proof = mul_two::generate_proof(a, b, c);
+                let proof_token = encode_proof(&proof);
+                println!("RES:{}", hex::encode(encode(&[proof_token])));
+            }
+        },
+        Commands::SumPow { action } => match action {
+            SumPowAction::PrintVkey => {
+                let vk = sum_pow::generate_verification_key();
+                let vk_token = encode_verification_key(&vk);
+                let encoded = encode(&[vk_token]);
+                println!("RES:{}", hex::encode(encoded));
+            }
+            SumPowAction::Prove { inputs, expected } => {
+                let inputs = inputs
+                    .iter()
+                    .map(|s| Scalar::from_hex_string(s).unwrap())
+                    .collect_vec();
+                let expected = Scalar::from_hex_string(&expected).unwrap();
+
+                let proof = sum_pow::generate_proof(inputs, expected);
+                let proof_token = encode_proof(&proof);
+                println!("RES:{}", hex::encode(encode(&[proof_token])));
+            }
+        },
+    }
+}
+
+// Helper function to encode proof
+fn encode_proof(proof: &PlonkProof) -> Token {
+    Token::Tuple(vec![
+        encode_g1_points(&proof.wire_comms),
+        encode_g1_point(&proof.z_comm),
+        encode_g1_points(&proof.quotient_comms),
+        encode_g1_point(&proof.w_zeta),
+        encode_g1_point(&proof.w_zeta_omega),
+        encode_scalars(&proof.wire_evals),
+        encode_scalars(&proof.sigma_evals),
+        encode_scalar(&proof.z_bar),
+    ])
+}
+
+// Helper function to encode verification key
+fn encode_verification_key(vk: &VerificationKey) -> Token {
+    Token::Tuple(vec![
+        Token::Uint(vk.n.into()),
+        Token::Uint(vk.l.into()),
+        encode_scalars(&vk.k),
+        encode_g1_points(&vk.q_comms),
+        encode_g1_points(&vk.sigma_comms),
+        encode_g1_point(&vk.g),
+        encode_g2_point(&vk.h),
+        encode_g2_point(&vk.x_h),
+    ])
+}
+
+// Helper functions to encode various types as ethabi tokens
+fn encode_g1_point(point: &G1Point) -> Token {
+    Token::Tuple(vec![
+        Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+            &point.x.into_bigint().to_bytes_le(),
+        )),
+        Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+            &point.y.into_bigint().to_bytes_le(),
+        )),
+    ])
+}
+
+fn encode_g2_point(point: &G2Point) -> Token {
+    Token::Tuple(vec![
+        Token::Array(vec![
+            Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+                &point.x.c0.into_bigint().to_bytes_le(),
+            )),
+            Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+                &point.x.c1.into_bigint().to_bytes_le(),
+            )),
+        ]),
+        Token::Array(vec![
+            Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+                &point.y.c0.into_bigint().to_bytes_le(),
+            )),
+            Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+                &point.y.c1.into_bigint().to_bytes_le(),
+            )),
+        ]),
+    ])
+}
+
+fn encode_g1_points<const N: usize>(points: &[G1Point; N]) -> Token {
+    Token::Array(points.iter().map(encode_g1_point).collect())
+}
+
+fn encode_scalar(scalar: &Fr) -> Token {
+    Token::Uint(ethabi::ethereum_types::U256::from_little_endian(
+        &scalar.into_bigint().to_bytes_le(),
+    ))
+}
+
+fn encode_scalars<const N: usize>(scalars: &[Fr; N]) -> Token {
+    Token::Array(scalars.iter().map(encode_scalar).collect())
+}

--- a/test/rust-reference-impls/verifier/src/mul_two.rs
+++ b/test/rust-reference-impls/verifier/src/mul_two.rs
@@ -1,0 +1,45 @@
+use super::*;
+use ark_bn254::Fr;
+use mpc_relation::traits::Circuit;
+use renegade_circuit_types::{traits::SingleProverCircuit, PlonkCircuit};
+use renegade_constants::Scalar;
+
+/// The mul two circuit
+///
+/// Takes as witness two values `a` and `b`, and a public input `c`
+///
+/// Constrains: `c = a * b`
+struct MulTwoCircuit;
+impl SingleProverCircuit for MulTwoCircuit {
+    type Statement = Scalar;
+    type Witness = [Scalar; 2];
+
+    fn name() -> String {
+        "mul-two".to_string()
+    }
+
+    fn apply_constraints(
+        witness_var: <Self::Witness as renegade_circuit_types::traits::CircuitBaseType>::VarType,
+        statement_var: <Self::Statement as renegade_circuit_types::traits::CircuitBaseType>::VarType,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), mpc_plonk::errors::PlonkError> {
+        let prod = cs.mul(witness_var[0], witness_var[1])?;
+        cs.enforce_equal(prod, statement_var)?;
+
+        Ok(())
+    }
+}
+
+/// Generate the verification key for the mul-two circuit
+pub fn generate_verification_key() -> VerificationKey {
+    let renegade_vk = MulTwoCircuit::verifying_key();
+    VerificationKey::from(renegade_vk.as_ref())
+}
+
+/// Generate a proof for the mul-two circuit
+pub fn generate_proof(a: Scalar, b: Scalar, c: Scalar) -> PlonkProof {
+    let statement = c;
+    let witness = [a, b];
+    let proof = MulTwoCircuit::prove(witness, statement).unwrap();
+    proof.into()
+}

--- a/test/rust-reference-impls/verifier/src/sum_pow.rs
+++ b/test/rust-reference-impls/verifier/src/sum_pow.rs
@@ -1,0 +1,46 @@
+use super::*;
+use ark_bn254::Fr;
+use mpc_relation::traits::Circuit;
+use renegade_circuit_types::{traits::SingleProverCircuit, PlonkCircuit};
+use renegade_constants::Scalar;
+
+const NUM_INPUTS: usize = 10;
+
+struct SumPowCircuit;
+impl SingleProverCircuit for SumPowCircuit {
+    type Statement = Scalar;
+    type Witness = [Scalar; NUM_INPUTS];
+
+    fn name() -> String {
+        "sum-pow".to_string()
+    }
+
+    fn apply_constraints(
+        witness_var: <Self::Witness as renegade_circuit_types::traits::CircuitBaseType>::VarType,
+        statement_var: <Self::Statement as renegade_circuit_types::traits::CircuitBaseType>::VarType,
+        cs: &mut PlonkCircuit,
+    ) -> Result<(), mpc_plonk::errors::PlonkError> {
+        let mut sum = cs.zero();
+        for value in witness_var.iter() {
+            sum = cs.add(sum, *value)?;
+        }
+
+        let sum_pow = cs.pow5(sum)?;
+        cs.enforce_equal(sum_pow, statement_var)?;
+        Ok(())
+    }
+}
+
+/// Generate the verification key for the sum-pow circuit
+pub fn generate_verification_key() -> VerificationKey {
+    let renegade_vk = SumPowCircuit::verifying_key();
+    VerificationKey::from(renegade_vk.as_ref())
+}
+
+/// Generate a proof for the sum-pow circuit
+pub fn generate_proof(inputs: Vec<Scalar>, expected: Scalar) -> PlonkProof {
+    let statement = expected;
+    let witness = inputs.try_into().unwrap();
+    let proof = SumPowCircuit::prove(witness, statement).unwrap();
+    proof.into()
+}

--- a/test/rust-reference-impls/verifier/src/types.rs
+++ b/test/rust-reference-impls/verifier/src/types.rs
@@ -1,0 +1,126 @@
+//! Types for the verifier solidity interface
+
+use ark_bn254::{Bn254, Fq, Fq2, Fr};
+use ark_ec::pairing::Pairing;
+use itertools::Itertools;
+use renegade_constants::SystemCurve;
+
+// Constants matching those in Types.sol
+const NUM_WIRE_TYPES: usize = 5;
+const NUM_SELECTORS: usize = 13;
+
+// --- Type Aliases --- //
+pub type VerifyingKey = mpc_plonk::proof_system::structs::VerifyingKey<SystemCurve>;
+
+// Struct definitions matching Solidity types
+#[derive(Debug, Clone, Copy)]
+pub struct G1Point {
+    pub(crate) x: Fq,
+    pub(crate) y: Fq,
+}
+
+impl G1Point {
+    pub fn from_affine(point: <Bn254 as Pairing>::G1Affine) -> Self {
+        Self {
+            x: point.x,
+            y: point.y,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct G2Point {
+    pub(crate) x: Fq2,
+    pub(crate) y: Fq2,
+}
+
+impl G2Point {
+    pub fn from_affine(point: <Bn254 as Pairing>::G2Affine) -> Self {
+        Self {
+            x: point.x,
+            y: point.y,
+        }
+    }
+}
+#[derive(Debug)]
+pub struct PlonkProof {
+    pub(crate) wire_comms: [G1Point; NUM_WIRE_TYPES],
+    pub(crate) z_comm: G1Point,
+    pub(crate) quotient_comms: [G1Point; NUM_WIRE_TYPES],
+    pub(crate) w_zeta: G1Point,
+    pub(crate) w_zeta_omega: G1Point,
+    pub(crate) wire_evals: [Fr; NUM_WIRE_TYPES],
+    pub(crate) sigma_evals: [Fr; NUM_WIRE_TYPES - 1],
+    pub(crate) z_bar: Fr,
+}
+
+impl From<mpc_plonk::proof_system::structs::Proof<SystemCurve>> for PlonkProof {
+    fn from(proof: mpc_plonk::proof_system::structs::Proof<SystemCurve>) -> Self {
+        PlonkProof {
+            wire_comms: proof
+                .wires_poly_comms
+                .iter()
+                .map(|c| G1Point::from_affine(c.0))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+            z_comm: G1Point::from_affine(proof.prod_perm_poly_comm.0),
+            quotient_comms: proof
+                .split_quot_poly_comms
+                .iter()
+                .map(|c| G1Point::from_affine(c.0))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+            w_zeta: G1Point::from_affine(proof.opening_proof.0),
+            w_zeta_omega: G1Point::from_affine(proof.shifted_opening_proof.0),
+            wire_evals: proof.poly_evals.wires_evals.clone().try_into().unwrap(),
+            sigma_evals: proof
+                .poly_evals
+                .wire_sigma_evals
+                .clone()
+                .try_into()
+                .unwrap(),
+            z_bar: proof.poly_evals.perm_next_eval,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VerificationKey {
+    pub(crate) n: u32,
+    pub(crate) l: u32,
+    pub(crate) k: [Fr; NUM_WIRE_TYPES],
+    pub(crate) q_comms: [G1Point; NUM_SELECTORS],
+    pub(crate) sigma_comms: [G1Point; NUM_WIRE_TYPES],
+    pub(crate) g: G1Point,
+    pub(crate) h: G2Point,
+    pub(crate) x_h: G2Point,
+}
+
+impl From<&VerifyingKey> for VerificationKey {
+    fn from(vk: &VerifyingKey) -> Self {
+        Self {
+            n: vk.domain_size as u32,
+            l: vk.num_inputs as u32,
+            k: vk.k.clone().try_into().unwrap(),
+            g: G1Point::from_affine(vk.open_key.g),
+            h: G2Point::from_affine(vk.open_key.h),
+            x_h: G2Point::from_affine(vk.open_key.beta_h),
+            q_comms: vk
+                .selector_comms
+                .iter()
+                .map(|c| G1Point::from_affine(c.0))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+            sigma_comms: vk
+                .sigma_comms
+                .iter()
+                .map(|c| G1Point::from_affine(c.0))
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds a reference implementation which has two commands:
- `print-vkeys`: Generates the vkeys for a circuit, ABI encodes them, and prints them to standard out
- `prove`: Proves a circuit given a witness, ABI encodes it, and prints the proof to standard out

There are two circuits; `mul-two` and `sum-pow`. `mul-pow` computes `a * b` and constrains this to a statement variable `c`. Sum pow makes use of the hash gates and computes `(x_1 + ... + x_10)^5`.

### Testing
- [x] Unit tests pass
- [ ] TODO: Hook into unit tests