### PR TITLE
libraries: poseidon2: poseidonSponge: Implement Huff poseidon2 sponge

### DIFF
--- a/src/libraries/merkle/main.huff
+++ b/src/libraries/merkle/main.huff
@@ -13,12 +13,22 @@
 /// @param idx The index of the input in the Merkle tree
 /// @param sisterLeaves An array of sister leaves to hash with
 /// @return The intermediate hashes of the input and sister leaves, with the root at the start
-#define function hashMerkle(uint256 idx, uint256 input, uint256[] sisterLeaves) nonpayable returns(uint256)
+#define function merkleHash(uint256 idx, uint256 input, uint256[] sisterLeaves) nonpayable returns(uint256)
+
+/// @notice Hash a series of inputs into a sponge and squeeze the first output
+/// @param inputs The inputs to hash
+/// @return The first output of the sponge
+#define function spongeHash(uint256[] inputs) nonpayable returns(uint256)
 
 // --- Constants --- //
 
 /// @notice The depth of the Merkle tree
 #define constant MERKLE_DEPTH = 0x20 // 32
+
+/// @dev The capacity of the sponge
+#define constant SPONGE_CAPACITY = 0x01
+/// @dev The rate of the sponge 
+#define constant SPONGE_RATE = 0x02 
 
 /// @dev The revert code for the `sisterLeaves` array length mismatch
 #define constant SISTER_LEAVES_LENGTH_MISMATCH = 0x01
@@ -31,7 +41,27 @@
 
 /// @notice Entrypoint for the Poseidon2 Merkle hash
 #define macro MAIN() = takes(0) returns(0) {
-    // Currently we only have one function, so we don't need to mux the selector
+    // Load the selector
+    0x00 calldataload 0xe0 shr          // [selector]
+    dup1 __FUNC_SIG(merkleHash) eq doMerkleHash jumpi
+    dup1 __FUNC_SIG(spongeHash) eq doSpongeHash jumpi
+    invalidSelector jump 
+
+    doMerkleHash:
+        MERKLE_HASH()
+    doSpongeHash:
+        SPONGE_HASH()
+    invalidSelector:
+    0x00 revert
+}
+
+// ----------
+// | Merkle |
+// ----------
+
+/// @dev Merkle hash the inputs
+/// @return The Merkle hash of the inputs
+#define macro MERKLE_HASH() = takes(0) returns(0) {
     // Push the data pointer of the return array onto the stack
     // The helpers below expect the data pointer to trail the inputs
     0x40                                // [*returnArr]
@@ -42,24 +72,24 @@
 
     // Load the data offset from the array start, then convert it to a data pointer 
     0x44 calldataload                   // [dataOffset, input, idx, *returnArr]
-    0x24 add                            // [*sisterLeaves, input, idx, *returnArr]
 
     // Load the length of the sister leaves array, then check its length
-    0x64 calldataload                   // [len(sisterLeaves), dataOffset, input, idx, *returnArr]
+    0x04 add dup1 calldataload          // [len(sisterLeaves), dataOffset, input, idx, *returnArr]
     [MERKLE_DEPTH] eq validLen jumpi    // [dataOffset, idx, input, *returnArr]
 
     [SISTER_LEAVES_LENGTH_MISMATCH] 0x00 mstore
     0x20 0x00 revert
 
     validLen:
+    0x20 add                            // [*sisterLeaves, input, idx, *returnArr]
     // Setup the return value
     // 1. Store the data offset at position 0x00
     // Offset is always 32 bytes in our case
-    0x20 0x00 mstore                    // [dataOffset, idx, input, *returnArr]
+    0x20 0x00 mstore                    // [*sisterLeaves, idx, input, *returnArr]
 
     // 2. Store the length of the return array at position 0x20
     // Length is always 32 in our case
-    0x20 0x20 mstore                    // [dataOffset, idx, input, *returnArr]
+    0x20 0x20 mstore                    // [*sisterLeaves, idx, input, *returnArr]
 
     // 3. Iteratively hash up the tree and store intermediate values in the array
     HASH_AND_STORE_MERKLE_LEVEL() // Level 1
@@ -152,7 +182,18 @@
         POSEIDON_TWO_TO_ONE()       // [hash]
 }
 
-// --- Helpers --- //
+// ----------
+// | Sponge |
+// ----------
+
+#define macro SPONGE_HASH() = takes(0) returns(0) {
+    0x04
+    RETURN_FIRST()
+}
+
+// -----------
+// | Helpers |
+// -----------
 
 /// @dev Push the lowest order bit of the input onto the stack
 #define macro LOWEST_BIT(input) = takes(1) returns(1) {

--- a/src/libraries/merkle/main.huff
+++ b/src/libraries/merkle/main.huff
@@ -191,14 +191,14 @@
 /// @param inputs A uint256 array of inputs to absorb
 /// @return The first squeezed scalar from the Poseidon sponge
 #define macro SPONGE_HASH() = takes(0) returns(0) {
-    // Load an initially zeroed sponge state
-    push0 push0 push0                           // [state[0], state[1], state[2]]
-
     // Load the inputs from calldata
-    0x04 calldataload                           // [dataOffset, state[0], state[1], state[2]]
-    0x04 add dup1 calldataload                  // [len(inputs), *arr, state[0], state[1], state[2]]
+    0x04 calldataload                           // [dataOffset]
+    0x04 add dup1 calldataload                  // [len(inputs), *arr]
+    dup2 0x20 add swap2 pop                     // [len(inputs), *nextElem]
 
-    swap1 0x20 add                              // [*nextElem, len(inputs), state[0], state[1], state[2]]
+    // Load the initially zero'd sponge state
+    push0 push0 push0                           // [state[0], state[1], state[2], len(inputs), *nextElem]
+
     POSEIDON_SPONGE_ABSORB()                    // [state'[0], state'[1], state'[2]]
     POSEIDON_SPONGE_SQUEEZE()                   // [state'[1], state'[0], state'[1], state'[2]]
     RETURN_FIRST()
@@ -240,6 +240,12 @@
 /// @dev Return the fourth value on the stack
 #define macro RETURN_FOURTH() = returns(0) {
     dup4 0x00 mstore
+    0x20 0x00 return
+}
+
+/// @dev Return the fifth value on the stack
+#define macro RETURN_FIFTH() = returns(0) {
+    dup5 0x00 mstore
     0x20 0x00 return
 }
 

--- a/src/libraries/merkle/main.huff
+++ b/src/libraries/merkle/main.huff
@@ -5,6 +5,7 @@
 
 #include "../poseidon2/poseidonUtils.huff"
 #include "../poseidon2/poseidonPerm.huff"
+#include "../poseidon2/poseidonSponge.huff"
 
 // --- Interface --- //
 
@@ -186,8 +187,20 @@
 // | Sponge |
 // ----------
 
+/// @dev Sponge hash the given inputs in calldata
+/// @param inputs A uint256 array of inputs to absorb
+/// @return The first squeezed scalar from the Poseidon sponge
 #define macro SPONGE_HASH() = takes(0) returns(0) {
-    0x04
+    // Load an initially zeroed sponge state
+    push0 push0 push0                           // [state[0], state[1], state[2]]
+
+    // Load the inputs from calldata
+    0x04 calldataload                           // [dataOffset, state[0], state[1], state[2]]
+    0x04 add dup1 calldataload                  // [len(inputs), *arr, state[0], state[1], state[2]]
+
+    swap1 0x20 add                              // [*nextElem, len(inputs), state[0], state[1], state[2]]
+    POSEIDON_SPONGE_ABSORB()                    // [state'[0], state'[1], state'[2]]
+    POSEIDON_SPONGE_SQUEEZE()                   // [state'[1], state'[0], state'[1], state'[2]]
     RETURN_FIRST()
 }
 

--- a/src/libraries/poseidon2/poseidonSponge.huff
+++ b/src/libraries/poseidon2/poseidonSponge.huff
@@ -1,38 +1,56 @@
 
 /// @dev Absorb elements from calldata into the sponge state
-#define macro POSEIDON_SPONGE_ABSORB() = takes(5) returns(3) {
-    // Takes    [len(inputs), *nextElem, state[0], state[1], state[2]]
-    // Returns  [state'[0], state'[1], state'[2]]
+/// @dev Behavior is undefined if the array is empty
+#define macro POSEIDON_SPONGE_ABSORB() = takes(5) returns(5) {
+    // Takes    [state[0], state[1], state[2], len(inputs), *nextElem]
+    // Returns  [state'[0], state'[1], state'[2], len(inputs), *nextElem]
 
+    // Jump to the last input if only one element needs to be absorbed
+    dup4 0x1 eq lastInput jumpi
+    // Absorb the first two inputs 
+    ABSORB_NEXT_TWO()                       // [state[0], state[1], state[2], len(inputs), *nextElem]
+    
     loopStart:
     // If we have one or zero elements left, the loop is done
-    dup1 0x02 gt lastInput jumpi            // [len(inputs), *nextElem, state[0], state[1], state[2]]
-    0x02 swap1 sub                          // [len(inputs) - 2, *nextElem, state[0], state[1], state[2]]
-    swap1                                   // [*nextElem, len(inputs) - 2, state[0], state[1], state[2]]
+    dup4 0x00 eq allAbsorbed jumpi          // [state[0], state[1], state[2], len(inputs), *nextElem]
 
-    // Otherwise, absorb the next two elements
-    dup1 calldataload swap1                 // [*nextElem, elem1, PRIME, len(inputs) - 2, state[0], state[1], state[2]]
-    0x20 add dup1 calldataload swap1        // [*nextElem, elem2, elem1, len(inputs) - 2, state[0], state[1], state[2]]
-    0x20 add swap3                          // [len(inputs) - 2, elem2, elem1, *nextElem, state[0], state[1], state[2]]
-    swap1 dup7 PUSH_PRIME() swap2 addmod    // [state'[2], len(inputs) - 2, elem1, *nextElem, state[0], state[1], state[2]]                              
-    swap2 dup6 PUSH_PRIME() swap2 addmod    // [state'[1], len(inputs) - 2, state'[2], *nextElem, state[0], state[1], state[2]]
-    swap1 swap5                             // [state[0], state'[1], state'[2], *nextElem, len(inputs) - 2, state[1], state[2]]
-    POSEIDON_PERM()                         // [state'[0], state'[1], state'[2], *nextElem, len(inputs) - 2, state[1], state[2]]
+    // Run the permutation
+    POSEIDON_PERM()                         // [state'[0], state'[1], state'[2], len(inputs), *nextElem]
+    dup4 0x01 eq lastInput jumpi            // [state'[0], state'[1], state'[2], len(inputs), *nextElem] 
 
-    // Cleanup for next round
-    swap4 swap1                             // [state'[1], len(inputs) - 2, state'[2], *nextElem, state'[0], state[1], state[2]]   
-    swap5 pop swap1                         // [state'[2], len(inputs) - 2, *nextElem, state'[0], state'[1], state[2]]
-    swap5 pop                               // [len(inputs) - 2, *nextElem, state'[0], state'[1], state'[2]]
+    // Absorb the next two elements then restart the loop
+    ABSORB_NEXT_TWO()                       // [state'[0], state'[1], state'[2], len(inputs), *nextElem]
     loopStart jump
     
-    lastInput:                              // [len(inputs), *nextElem, state[0], state[1], state[2]]
-    0x00 eq allAbsorbed jumpi               // [*nextElem, state[0], state[1], state[2]]
-    dup1 calldataload                       // [elem1, *nextElem, state[0], state[1], state[2]]
-    dup4 PUSH_PRIME() swap2 addmod          // [state'[1], *nextElem, state[0], state[1], state[2]]
-    swap3 pop                               // [*nextElem, state[0], state'[1], state[2]]
+    // Take care of a remaining input for odd-length input arrays
+    lastInput:                              // [state[0], state[1], state[2], len(inputs), *nextElem]
+    dup5 calldataload                       // [elem1, state[0], state[1], state[2], len(inputs), *nextElem]
+    dup3 PUSH_PRIME() swap2 addmod          // [state'[1], state[0], state[1], state[2], len(inputs), *nextElem]
+    swap2 pop                               // [state[0], state'[1], state[2], len(input), *nextElem]
 
-    allAbsorbed:                            // [*nextElem, state[0], state[1], state[2]]
-    pop                                     // [state[0], state[1], state[2]]
+    allAbsorbed:                            // [state[0], state[1], state[2], len(input), *nextElem]
+}
+
+/// @dev Absorb two inputs into the state, adding them to the existing state without permutation
+#define macro ABSORB_NEXT_TWO() = takes(5) returns(5) {
+    // Takes    [state[0], state[1], state[2], len(inputs), *nextElem]
+    // Returns  [state'[0], state'[1], state'[2], len(inputs) - 2, *nextElem + 64]
+
+    // Decrement the number of inputs left 
+    0x2 dup5 sub swap4 pop                   // [state[0], state[1], state[2], len(inputs) - 2, *nextElem]
+    
+    // Load in the next two elements from the inputs and increment the data pointer
+    dup5 dup1 calldataload swap1 0x20 add       // [*nextElem + 32, elem1, state[0], state[1], state[2], len(inputs) - 2, *nextElem]
+    dup1 calldataload swap1 0x20 add            // [*nextElem + 64, elem2, elem1, state[0], state[1], state[2], len(inputs) - 2, *nextElem]
+    swap7 pop                                   // [elem2, elem1, state[0], state[1], state[2], len(inputs) - 2, *nextElem + 64]
+
+    // Add elem2 to state[2]
+    dup5 PUSH_PRIME() swap2 addmod              // [state'[2], elem1, state[0], state[1], state[2], len(inputs) - 2, *nextElem + 64]
+    swap4 pop                                   // [elem1, state[0], state[1], state'[2], len(inputs) - 2, *nextElem + 64]
+    
+    // Add elem1 to state[1]
+    dup3 PUSH_PRIME() swap2 addmod              // [state'[1], state[0], state[1], state'[2], len(inputs) - 2, *nextElem + 64]
+    swap2 pop                                   // [state[0], state'[1], state'[2], len(inputs) - 2, *nextElem + 64]
 }
 
 /// @dev Squeeze a scalar from a poseidon sponge

--- a/src/libraries/poseidon2/poseidonSponge.huff
+++ b/src/libraries/poseidon2/poseidonSponge.huff
@@ -1,0 +1,49 @@
+
+/// @dev Absorb elements from calldata into the sponge state
+#define macro POSEIDON_SPONGE_ABSORB() = takes(5) returns(3) {
+    // Takes    [len(inputs), *nextElem, state[0], state[1], state[2]]
+    // Returns  [state'[0], state'[1], state'[2]]
+
+    loopStart:
+    // If we have one or zero elements left, the loop is done
+    dup1 0x02 gt lastInput jumpi            // [len(inputs), *nextElem, state[0], state[1], state[2]]
+    0x02 swap1 sub                          // [len(inputs) - 2, *nextElem, state[0], state[1], state[2]]
+    swap1                                   // [*nextElem, len(inputs) - 2, state[0], state[1], state[2]]
+
+    // Otherwise, absorb the next two elements
+    dup1 calldataload swap1                 // [*nextElem, elem1, PRIME, len(inputs) - 2, state[0], state[1], state[2]]
+    0x20 add dup1 calldataload swap1        // [*nextElem, elem2, elem1, len(inputs) - 2, state[0], state[1], state[2]]
+    0x20 add swap3                          // [len(inputs) - 2, elem2, elem1, *nextElem, state[0], state[1], state[2]]
+    swap1 dup7 PUSH_PRIME() swap2 addmod    // [state'[2], len(inputs) - 2, elem1, *nextElem, state[0], state[1], state[2]]                              
+    swap2 dup6 PUSH_PRIME() swap2 addmod    // [state'[1], len(inputs) - 2, state'[2], *nextElem, state[0], state[1], state[2]]
+    swap1 swap5                             // [state[0], state'[1], state'[2], *nextElem, len(inputs) - 2, state[1], state[2]]
+    POSEIDON_PERM()                         // [state'[0], state'[1], state'[2], *nextElem, len(inputs) - 2, state[1], state[2]]
+
+    // Cleanup for next round
+    swap4 swap1                             // [state'[1], len(inputs) - 2, state'[2], *nextElem, state'[0], state[1], state[2]]   
+    swap5 pop swap1                         // [state'[2], len(inputs) - 2, *nextElem, state'[0], state'[1], state[2]]
+    swap5 pop                               // [len(inputs) - 2, *nextElem, state'[0], state'[1], state'[2]]
+    loopStart jump
+    
+    lastInput:                              // [len(inputs), *nextElem, state[0], state[1], state[2]]
+    0x00 eq allAbsorbed jumpi               // [*nextElem, state[0], state[1], state[2]]
+    dup1 calldataload                       // [elem1, *nextElem, state[0], state[1], state[2]]
+    dup4 PUSH_PRIME() swap2 addmod          // [state'[1], *nextElem, state[0], state[1], state[2]]
+    swap3 pop                               // [*nextElem, state[0], state'[1], state[2]]
+
+    allAbsorbed:                            // [*nextElem, state[0], state[1], state[2]]
+    pop                                     // [state[0], state[1], state[2]]
+}
+
+/// @dev Squeeze a scalar from a poseidon sponge
+#define macro POSEIDON_SPONGE_SQUEEZE() = takes(3) returns(4) {
+    // Takes    [state[0], state[1], state[2]]
+    // Returns  [squeezed, state[0], state[1], state[2]]
+
+    // 1. Apply the permutation when the squeeze state starts
+    POSEIDON_PERM()         // [state'[0], state'[1], state'[2]]
+
+    // We do not squeeze from the first `CAPACITY` state elements, in our
+    // case, `CAPACITY = 1`, so we return the second element after permutation
+    dup2                    // [state'[1], state'[0], state'[1], state'[2]]
+}

--- a/test/Merkle.t.sol
+++ b/test/Merkle.t.sol
@@ -5,6 +5,7 @@ import { Test } from "forge-std/Test.sol";
 import { console } from "forge-std/console.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { TestUtils } from "./utils/TestUtils.sol";
+import { console2 } from "forge-std/console2.sol";
 
 contract MerkleTest is TestUtils {
     /// @dev The Merkle depth
@@ -26,13 +27,24 @@ contract MerkleTest is TestUtils {
         for (uint256 i = 0; i < MERKLE_DEPTH; i++) {
             sisterLeaves[i] = randomFelt();
         }
-        uint256[] memory results = merklePoseidon.hashMerkle(idx, input, sisterLeaves);
+        uint256[] memory results = merklePoseidon.merkleHash(idx, input, sisterLeaves);
         uint256[] memory expected = runReferenceImpl(idx, input, sisterLeaves);
         assertEq(results.length, MERKLE_DEPTH, "Expected 32 results");
 
         for (uint256 i = 0; i < MERKLE_DEPTH; i++) {
             assertEq(results[i], expected[i], string(abi.encodePacked("Result mismatch at index ", vm.toString(i))));
         }
+    }
+
+    /// @dev Test the spongeHash function
+    function testSpongeHash() public {
+        uint256[] memory inputs = new uint256[](3);
+        inputs[0] = randomFelt();
+        inputs[1] = randomFelt();
+        inputs[2] = randomFelt();
+
+        uint256 result = merklePoseidon.spongeHash(inputs);
+        console2.log("Result: %s", result);
     }
 
     // --- Helpers --- //
@@ -73,11 +85,13 @@ contract MerkleTest is TestUtils {
 }
 
 interface MerklePoseidon {
-    function hashMerkle(
+    function merkleHash(
         uint256 idx,
         uint256 input,
         uint256[] calldata sisterLeaves
     )
         external
         returns (uint256[] memory);
+
+    function spongeHash(uint256[] calldata inputs) external returns (uint256);
 }

--- a/test/Merkle.t.sol
+++ b/test/Merkle.t.sol
@@ -38,10 +38,11 @@ contract MerkleTest is TestUtils {
 
     /// @dev Test the spongeHash function
     function testSpongeHash() public {
-        uint256[] memory inputs = new uint256[](3);
-        inputs[0] = randomFelt();
-        inputs[1] = randomFelt();
-        inputs[2] = randomFelt();
+        uint256[] memory inputs = new uint256[](4);
+        inputs[0] = 1;
+        inputs[1] = 2;
+        inputs[2] = 3;
+        inputs[3] = 4;
 
         uint256 result = merklePoseidon.spongeHash(inputs);
         console2.log("Result: %s", result);


### PR DESCRIPTION
### Purpose
This PR implements a sponge structure on top of the already implemented Poseidon2 permutation. I also added a reference implementation that uses the poseidon hash methods defined in the relayer source.

### Testing
- [x] All tests pass
- [x] Tested the sponge on variable length inputs