### PR TITLE
Darkpool: Compute wallet share commitment

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -7,6 +7,7 @@ import { VerifierCore } from "./libraries/verifier/VerifierCore.sol";
 import { VerificationKeys } from "./libraries/darkpool/VerificationKeys.sol";
 import { console2 } from "forge-std/console2.sol";
 import { IHasher } from "./libraries/merkle/IHasher.sol";
+import { IVerifier } from "./libraries/verifier/IVerifier.sol";
 import { ValidWalletCreateStatement, StatementSerializer } from "./libraries/darkpool/PublicInputs.sol";
 
 // Use the StatementSerializer for all statements
@@ -15,23 +16,34 @@ using StatementSerializer for ValidWalletCreateStatement;
 contract Darkpool {
     /// @notice The hasher for the darkpool
     IHasher public hasher;
+    /// @notice The verifier for the darkpool
+    IVerifier public verifier;
 
     /// @notice The constructor for the darkpool
     /// @param hasher_ The hasher for the darkpool
-    constructor(IHasher hasher_) {
+    /// @param verifier_ The verifier for the darkpool
+    constructor(IHasher hasher_, IVerifier verifier_) {
         hasher = hasher_;
+        verifier = verifier_;
     }
 
     /// @notice Create a wallet in the darkpool
     /// @param statement The statement to verify
     /// @param proof The proof of `VALID WALLET CREATE`
     function createWallet(ValidWalletCreateStatement memory statement, PlonkProof memory proof) public view {
-        // Load the verification key from the constant
-        VerificationKey memory vk = abi.decode(VerificationKeys.VALID_WALLET_CREATE_VKEY, (VerificationKey));
-
         // 1. Verify the proof
-        // Serialize the public inputs
-        BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
-        VerifierCore.verify(proof, publicInputs, vk);
+        verifier.verifyValidWalletCreate(statement, proof);
+
+        // 2. Compute a commitment to the wallet shares
+        uint256[] memory hashInputs = new uint256[](statement.publicShares.length + 1);
+        hashInputs[0] = BN254.ScalarField.unwrap(statement.privateShareCommitment);
+        for (uint256 i = 1; i <= statement.publicShares.length; i++) {
+            hashInputs[i] = BN254.ScalarField.unwrap(statement.publicShares[i - 1]);
+        }
+        uint256 walletCommitment = hasher.spongeHash(hashInputs);
+        console2.log("walletCommitment", walletCommitment);
+
+        // 3. Insert the wallet commitment into the Merkle tree
+        // TODO: Implement Merkle tree
     }
 }

--- a/src/libraries/darkpool/PublicInputs.sol
+++ b/src/libraries/darkpool/PublicInputs.sol
@@ -5,6 +5,9 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 
 // This file represents the public inputs (statements) for various proofs used by the darkpool
 
+/// @dev The number of public shares in a wallet
+uint256 constant N_WALLET_SHARES = 70;
+
 // -------------------
 // | Statement Types |
 // -------------------
@@ -12,7 +15,7 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 /// @title ValidWalletCreateStatement the statement type for the `VALID WALLET CREATE` proof
 struct ValidWalletCreateStatement {
     /// @dev The commitment to the wallet's private shares
-    BN254.ScalarField walletCommitment;
+    BN254.ScalarField privateShareCommitment;
     /// @dev The public wallet shares of the wallet
     BN254.ScalarField[] publicShares;
 }
@@ -33,11 +36,11 @@ library StatementSerializer {
         pure
         returns (BN254.ScalarField[] memory)
     {
-        // Create array with size = 1 (for walletCommitment) + publicShares.length
+        // Create array with size = 1 (for privateShareCommitment) + publicShares.length
         BN254.ScalarField[] memory serialized = new BN254.ScalarField[](1 + self.publicShares.length);
 
         // Add the wallet commitment
-        serialized[0] = self.walletCommitment;
+        serialized[0] = self.privateShareCommitment;
 
         // Add all public shares
         for (uint256 i = 0; i < self.publicShares.length; i++) {
@@ -57,8 +60,8 @@ library StatementSerializer {
     {
         require(serialized.length >= 1, "Invalid serialized statement length");
 
-        // Extract the wallet commitment
-        statement.walletCommitment = serialized[0];
+        // Extract the private share commitment
+        statement.privateShareCommitment = serialized[0];
 
         // Extract the public shares
         statement.publicShares = new BN254.ScalarField[](serialized.length - 1);

--- a/src/libraries/verifier/VerifierCore.sol
+++ b/src/libraries/verifier/VerifierCore.sol
@@ -79,7 +79,7 @@ library VerifierCore {
         returns (bool)
     {
         plonkStep1And2(proofs);
-        plonkStep3(publicInputs);
+        plonkStep3(publicInputs, vks);
         Challenges[] memory batchChallenges = plonkStep4(proofs, publicInputs, vks);
 
         // Get the base root of unity for the circuit's evaluation domain
@@ -222,9 +222,10 @@ library VerifierCore {
 
     /// @notice Step 3 of the plonk verification algorithm
     /// @notice Verify that the public inputs to the proof are all in the scalar field
-    function plonkStep3(BN254.ScalarField[][] memory publicInputs) internal pure {
+    function plonkStep3(BN254.ScalarField[][] memory publicInputs, VerificationKey[] memory vks) internal pure {
         // Check that the public inputs are all in the scalar field
         for (uint256 i = 0; i < publicInputs.length; i++) {
+            require(publicInputs[i].length == vks[i].l, "Invalid public input length");
             for (uint256 j = 0; j < publicInputs[i].length; j++) {
                 BN254.validateScalarField(publicInputs[i][j]);
             }

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -3,10 +3,13 @@ pragma solidity ^0.8.0;
 
 import { Test } from "forge-std/Test.sol";
 import { BN254 } from "lib/solidity-bn254/src/BN254.sol";
+import { N_WALLET_SHARES } from "src/libraries/darkpool/PublicInputs.sol";
 
 contract TestUtils is Test {
     /// @dev The BN254 field modulus from roundUtils.huff
     uint256 constant PRIME = BN254.R_MOD;
+
+    // --- Fuzzing Helpers --- //
 
     /// @dev Generates a random input modulo the PRIME
     /// Note that this is not uniformly distributed over the prime field, because of the "wraparound"
@@ -38,6 +41,15 @@ contract TestUtils is Test {
 
         uint256 range = high - low;
         return low + (vm.randomUint() % range);
+    }
+
+    /// @dev Generate a random set of wallet shares
+    function randomWalletShares() internal returns (BN254.ScalarField[] memory) {
+        BN254.ScalarField[] memory shares = new BN254.ScalarField[](N_WALLET_SHARES);
+        for (uint256 i = 0; i < N_WALLET_SHARES; i++) {
+            shares[i] = BN254.ScalarField.wrap(randomFelt());
+        }
+        return shares;
     }
 
     // --- FFI Helpers --- //


### PR DESCRIPTION
### Purpose
This PR computes the wallet share commitment in the `createWallet` method. 

### Testing
- [x] All unit tests pass