### PR TITLE
Darkpool: Implement initial logic in `update_wallet` method

### DIFF
--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -2,13 +2,18 @@
 pragma solidity ^0.8.0;
 
 import { PlonkProof, VerificationKey } from "./libraries/verifier/Types.sol";
-import { ValidWalletCreateStatement, StatementSerializer } from "./libraries/darkpool/PublicInputs.sol";
+import {
+    ValidWalletCreateStatement,
+    ValidWalletUpdateStatement,
+    StatementSerializer
+} from "./libraries/darkpool/PublicInputs.sol";
 import { VerificationKeys } from "./libraries/darkpool/VerificationKeys.sol";
 import { IVerifier } from "./libraries/verifier/IVerifier.sol";
 import { VerifierCore } from "./libraries/verifier/VerifierCore.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 
 using StatementSerializer for ValidWalletCreateStatement;
+using StatementSerializer for ValidWalletUpdateStatement;
 
 /// @title PlonK Verifier with the Jellyfish-style arithmetization
 /// @notice The methods on this contract are darkpool-specific
@@ -26,6 +31,23 @@ contract Verifier is IVerifier {
         returns (bool)
     {
         VerificationKey memory vk = abi.decode(VerificationKeys.VALID_WALLET_CREATE_VKEY, (VerificationKey));
+        BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
+        return VerifierCore.verify(proof, publicInputs, vk);
+    }
+
+    /// @notice Verify a proof of `VALID WALLET UPDATE`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidWalletUpdate(
+        ValidWalletUpdateStatement memory statement,
+        PlonkProof memory proof
+    )
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = abi.decode(VerificationKeys.VALID_WALLET_UPDATE_VKEY, (VerificationKey));
         BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
         return VerifierCore.verify(proof, publicInputs, vk);
     }

--- a/src/libraries/darkpool/PublicInputs.sol
+++ b/src/libraries/darkpool/PublicInputs.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { ExternalTransfer, PublicRootKey } from "./Types.sol";
 
 // This file represents the public inputs (statements) for various proofs used by the darkpool
 
@@ -17,12 +18,33 @@ struct ValidWalletCreateStatement {
     BN254.ScalarField[] publicShares;
 }
 
+/// @title ValidWalletUpdateStatement the statement type for the `VALID WALLET UPDATE` proof
+struct ValidWalletUpdateStatement {
+    /// @dev The nullifier of the previous wallet
+    BN254.ScalarField previousNullifier;
+    /// @dev A commitment to the new wallet's private shares
+    BN254.ScalarField newPrivateShareCommitment;
+    /// @dev The new public shares of the wallet
+    BN254.ScalarField[] newPublicShares;
+    /// @dev The global Merkle root that the old wallet shares open into
+    BN254.ScalarField merkleRoot;
+    /// @dev The external transfer in the update, zeroed out if there is no transfer
+    ExternalTransfer externalTransfer;
+    /// @dev The old public root key of the keychain
+    PublicRootKey oldPkRoot;
+}
+
 // ------------------------
 // | Scalar Serialization |
 // ------------------------
 
 /// @title StatementSerializer Library for serializing statement types to scalar arrays
 library StatementSerializer {
+    using StatementSerializer for ValidWalletCreateStatement;
+    using StatementSerializer for ValidWalletUpdateStatement;
+    using StatementSerializer for ExternalTransfer;
+    using StatementSerializer for PublicRootKey;
+
     // --- Valid Wallet Create --- //
 
     /// @notice Serializes a ValidWalletCreateStatement into an array of scalar field elements
@@ -47,26 +69,68 @@ library StatementSerializer {
         return serialized;
     }
 
-    /// @notice Deserializes an array of scalar field elements into a ValidWalletCreateStatement
-    /// @param serialized The serialized statement as an array of scalar field elements
-    /// @return statement The deserialized ValidWalletCreateStatement
-    function scalarDeserialize(BN254.ScalarField[] memory serialized)
+    // --- Valid Wallet Update --- //
+
+    /// @notice Serializes a ValidWalletUpdateStatement into an array of scalar field elements
+    /// @param self The statement to serialize
+    /// @return serialized The serialized statement as an array of scalar field elements
+    function scalarSerialize(ValidWalletUpdateStatement memory self)
         internal
         pure
-        returns (ValidWalletCreateStatement memory statement)
+        returns (BN254.ScalarField[] memory)
     {
-        require(serialized.length >= 1, "Invalid serialized statement length");
+        BN254.ScalarField[] memory serialized = new BN254.ScalarField[](1 + 1 + self.newPublicShares.length);
+        serialized[0] = self.previousNullifier;
+        serialized[1] = self.newPrivateShareCommitment;
 
-        // Extract the private share commitment
-        statement.privateShareCommitment = serialized[0];
-
-        // Extract the public shares
-        statement.publicShares = new BN254.ScalarField[](serialized.length - 1);
-        for (uint256 i = 0; i < serialized.length - 1; i++) {
-            statement.publicShares[i] = serialized[i + 1];
+        // Copy the public shares
+        uint256 n = self.newPublicShares.length;
+        for (uint256 i = 0; i < n; i++) {
+            serialized[i + 2] = self.newPublicShares[i];
         }
 
-        return statement;
+        serialized[n + 2] = self.merkleRoot;
+        BN254.ScalarField[] memory externalTransferSerialized = self.externalTransfer.scalarSerialize();
+        for (uint256 i = 0; i < externalTransferSerialized.length; i++) {
+            serialized[n + 3 + i] = externalTransferSerialized[i];
+        }
+
+        BN254.ScalarField[] memory oldPkRootSerialized = self.oldPkRoot.scalarSerialize();
+        for (uint256 i = 0; i < oldPkRootSerialized.length; i++) {
+            serialized[n + 3 + externalTransferSerialized.length + i] = oldPkRootSerialized[i];
+        }
+
+        return serialized;
+    }
+
+    // --- Types --- //
+
+    /// @notice Serializes an ExternalTransfer into an array of scalar field elements
+    /// @param self The transfer to serialize
+    /// @return serialized The serialized transfer as an array of scalar field elements
+    function scalarSerialize(ExternalTransfer memory self) internal pure returns (BN254.ScalarField[] memory) {
+        BN254.ScalarField[] memory serialized = new BN254.ScalarField[](4);
+
+        serialized[0] = BN254.ScalarField.wrap(uint256(uint160(self.account)));
+        serialized[1] = BN254.ScalarField.wrap(uint256(uint160(self.mint)));
+        serialized[2] = BN254.ScalarField.wrap(self.amount);
+        serialized[3] = BN254.ScalarField.wrap(self.timestamp);
+
+        return serialized;
+    }
+
+    /// @notice Serializes a PublicRootKey into an array of scalar field elements
+    /// @param self The key to serialize
+    /// @return serialized The serialized key as an array of scalar field elements
+    function scalarSerialize(PublicRootKey memory self) internal pure returns (BN254.ScalarField[] memory) {
+        BN254.ScalarField[] memory serialized = new BN254.ScalarField[](4);
+
+        serialized[0] = self.x[0];
+        serialized[1] = self.x[1];
+        serialized[2] = self.y[0];
+        serialized[3] = self.y[1];
+
+        return serialized;
     }
 }
 

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+// This file contains the types used in the darkpool
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+// ---------------------
+// | External Transfer |
+// ---------------------
+
+/// @notice An external transfer representing a deposit or withdrawal into/from the darkpool
+struct ExternalTransfer {
+    /// @dev The account address of the sender/recipient
+    address account;
+    /// @dev The mint (erc20 address) of the token
+    address mint;
+    /// @dev The amount of the transfer
+    uint256 amount;
+    /// @dev The timestamp of the transfer
+    uint256 timestamp;
+    /// @dev Indicates if it's a deposit or withdrawal
+    TransferType transferType;
+}
+
+/// @notice The type of transfer
+enum TransferType {
+    Deposit,
+    Withdrawal
+}
+
+// ------------
+// | Keychain |
+// ------------
+
+/// @notice A public root key, essentially a `Scalar` representation of a k256 public key
+/// @dev The `x` and `y` coordinates are elements of the base field of the k256 curve, which
+/// @dev each require 254 bits to represent
+struct PublicRootKey {
+    /// @dev The x coordinate of the public key
+    BN254.ScalarField[2] x;
+    /// @dev The y coordinate of the public key
+    BN254.ScalarField[2] y;
+}

--- a/src/libraries/verifier/IVerifier.sol
+++ b/src/libraries/verifier/IVerifier.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { PlonkProof } from "./Types.sol";
-import { ValidWalletCreateStatement } from "../darkpool/PublicInputs.sol";
+import { ValidWalletCreateStatement, ValidWalletUpdateStatement } from "../darkpool/PublicInputs.sol";
 
 interface IVerifier {
     /// @notice Verify a proof of `VALID WALLET CREATE`
@@ -11,6 +11,18 @@ interface IVerifier {
     /// @return True if the proof is valid, false otherwise
     function verifyValidWalletCreate(
         ValidWalletCreateStatement memory statement,
+        PlonkProof memory proof
+    )
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `VALID WALLET UPDATE`
+    /// @param proof The proof to verify
+    /// @param statement The public inputs to the proof
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidWalletUpdate(
+        ValidWalletUpdateStatement memory statement,
         PlonkProof memory proof
     )
         external

--- a/test/Merkle.t.sol
+++ b/test/Merkle.t.sol
@@ -145,18 +145,18 @@ contract MerkleTest is TestUtils {
         uint256 expectedRoot = BN254.ScalarField.unwrap(tree.getRoot());
         uint256 openedRoot = nextInput;
         for (uint256 i = 0; i < MERKLE_DEPTH; i++) {
-            uint256[] memory inputs = new uint256[](2);
+            uint256[] memory hashTwoInputs = new uint256[](2);
             uint256 ithBit = (idx >> i) & 1;
             if (ithBit == 0) {
                 // Left child
-                inputs[0] = openedRoot;
-                inputs[1] = siblingPath[i];
+                hashTwoInputs[0] = openedRoot;
+                hashTwoInputs[1] = siblingPath[i];
             } else {
                 // Right child
-                inputs[0] = siblingPath[i];
-                inputs[1] = openedRoot;
+                hashTwoInputs[0] = siblingPath[i];
+                hashTwoInputs[1] = openedRoot;
             }
-            openedRoot = hasher.spongeHash(inputs);
+            openedRoot = hasher.spongeHash(hashTwoInputs);
         }
 
         assertEq(openedRoot, expectedRoot);

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -2,13 +2,18 @@
 pragma solidity ^0.8.0;
 
 import { PlonkProof, VerificationKey } from "../../src/libraries/verifier/Types.sol";
-import { ValidWalletCreateStatement, StatementSerializer } from "../../src/libraries/darkpool/PublicInputs.sol";
+import {
+    ValidWalletCreateStatement,
+    ValidWalletUpdateStatement,
+    StatementSerializer
+} from "../../src/libraries/darkpool/PublicInputs.sol";
 import { VerificationKeys } from "../../src/libraries/darkpool/VerificationKeys.sol";
 import { IVerifier } from "../../src/libraries/verifier/IVerifier.sol";
 import { VerifierCore } from "../../src/libraries/verifier/VerifierCore.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 
 using StatementSerializer for ValidWalletCreateStatement;
+using StatementSerializer for ValidWalletUpdateStatement;
 
 /// @title Test Verifier Implementation
 /// @notice This is a test implementation of the `IVerifier` interface that always returns true
@@ -27,6 +32,24 @@ contract TestVerifier is IVerifier {
         returns (bool)
     {
         VerificationKey memory vk = abi.decode(VerificationKeys.VALID_WALLET_CREATE_VKEY, (VerificationKey));
+        BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
+        VerifierCore.verify(proof, publicInputs, vk);
+        return true;
+    }
+
+    /// @notice Verify a proof of `VALID WALLET UPDATE`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidWalletUpdate(
+        ValidWalletUpdateStatement memory statement,
+        PlonkProof memory proof
+    )
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = abi.decode(VerificationKeys.VALID_WALLET_UPDATE_VKEY, (VerificationKey));
         BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
         VerifierCore.verify(proof, publicInputs, vk);
         return true;


### PR DESCRIPTION
### Purpose
This PR makes an initial implementation of the `update_wallet` method on the darkpool. Left todo are the following:
- Check the signature of the new wallet commitment by the old secret root key
- Execute any transfers implied by the update

### Testing
- [x] All unit tests pass