### PR TITLE
libraries: darkpool: NullifierSet: Implement nullifier set

### DIFF
--- a/src/libraries/darkpool/NullifierSet.sol
+++ b/src/libraries/darkpool/NullifierSet.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+/// @title NullifierSet
+/// @notice Tracks the set of spent nullifiers in the darkpool, ensuring that a pre-update wallet
+/// @notice cannot create two separate post-update wallets
+library Nullifiers {
+    using Nullifiers for Nullifiers.NullifierSet;
+
+    /// @notice The nullifiers in the set
+    struct NullifierSet {
+        mapping(uint256 => bool) nullifiers;
+    }
+
+    /// @notice Check if a nullifier has been spent
+    /// @param nullifier The nullifier to check
+    /// @return True if the nullifier has been spent, false otherwise
+    function isSpent(NullifierSet storage self, BN254.ScalarField nullifier) public view returns (bool) {
+        uint256 nullifierUint = BN254.ScalarField.unwrap(nullifier);
+        return self.nullifiers[nullifierUint];
+    }
+
+    /// @notice Mark a nullifier as spent
+    /// @param nullifier The nullifier to spend
+    function spend(NullifierSet storage self, BN254.ScalarField nullifier) public {
+        require(!isSpent(self, nullifier), "Nullifier already spent");
+        uint256 nullifierUint = BN254.ScalarField.unwrap(nullifier);
+        self.nullifiers[nullifierUint] = true;
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds a `NullifierSet` library to the darkpool libraries. I added a test for the basic nullifier set functionality.

### Testing
- [x] All unit tests pass