### PR TITLE
libraries: darkpool: ExternalTransfers: Implement deposit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/solidity-bn254"]
 	path = lib/solidity-bn254
 	url = https://github.com/joeykraut/solidity-bn254
+[submodule "lib/permit2"]
+	path = lib/permit2
+	url = https://github.com/Uniswap/permit2

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,3 +4,4 @@ foundry-huff/=lib/foundry-huff/src/
 solidity-stringutils/=lib/foundry-huff/lib/solidity-stringutils/
 stringutils/=lib/foundry-huff/lib/solidity-stringutils/
 solidity-bn254/=lib/solidity-bn254/src/
+permit2/=lib/permit2/src/

--- a/src/libraries/darkpool/ExternalTransfers.sol
+++ b/src/libraries/darkpool/ExternalTransfers.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {
+    ExternalTransfer,
+    TransferType,
+    TransferAuthorization,
+    PublicRootKey,
+    publicKeyToUints,
+    DepositWitness,
+    hashDepositWitness,
+    DEPOSIT_WITNESS_TYPE_STRING
+} from "../darkpool/Types.sol";
+import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
+import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
+
+// @title TransferExecutor
+// @notice This library implements the logic for executing external transfers
+// @notice External transfers are either deposits or withdrawals into/from the darkpool
+library TransferExecutor {
+    /// @notice Executes an external transfer (deposit or withdrawal) for the darkpool
+    /// @param transfer The external transfer details including account, mint, amount and type
+    /// @param oldPkRoot The public root key of the sender's Renegade wallet
+    /// @param authorization The authorization data for the transfer (permit2 or withdrawal signature)
+    /// @param permit2 The Permit2 contract instance for handling deposits
+    function executeTransfer(
+        ExternalTransfer calldata transfer,
+        PublicRootKey calldata oldPkRoot,
+        TransferAuthorization calldata authorization,
+        IPermit2 permit2
+    )
+        internal
+    {
+        bool isDeposit = transfer.transferType == TransferType.Deposit;
+        if (isDeposit) {
+            executeDeposit(oldPkRoot, transfer, authorization, permit2);
+        } else {
+            executeWithdrawal(transfer);
+        }
+    }
+
+    // --- Deposit --- //
+
+    /// @notice Executes a deposit of shares into the darkpool
+    /// @dev Deposits flow through the permit2 contract, which allows us to attach the public root
+    /// @dev key to the deposit's witness. This provides a link between the on-chain wallet and the
+    /// @dev Renegade wallet, ensuring that only one Renegade wallet may redeem the permit.
+    /// @param transfer The transfer to execute
+    /// @param authorization The authorization for the deposit
+    /// @param permit2 The permit2 contract
+    function executeDeposit(
+        PublicRootKey calldata oldPkRoot,
+        ExternalTransfer calldata transfer,
+        TransferAuthorization calldata authorization,
+        IPermit2 permit2
+    )
+        internal
+    {
+        // Build the permit
+        ISignatureTransfer.TokenPermissions memory tokenPermissions =
+            ISignatureTransfer.TokenPermissions({ token: transfer.mint, amount: transfer.amount });
+        ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer.PermitTransferFrom({
+            permitted: tokenPermissions,
+            nonce: authorization.permit2Nonce,
+            deadline: authorization.permit2Deadline
+        });
+        ISignatureTransfer.SignatureTransferDetails memory signatureTransferDetails =
+            ISignatureTransfer.SignatureTransferDetails({ to: address(this), requestedAmount: transfer.amount });
+        DepositWitness memory depositWitness = DepositWitness({ pkRoot: publicKeyToUints(oldPkRoot) });
+        bytes32 depositWitnessHash = hashDepositWitness(depositWitness);
+
+        address owner = transfer.account;
+        permit2.permitWitnessTransferFrom(
+            permit,
+            signatureTransferDetails,
+            owner,
+            depositWitnessHash,
+            DEPOSIT_WITNESS_TYPE_STRING,
+            authorization.permit2Signature
+        );
+    }
+
+    /// @notice Builds the deposit witness hash from the public root key
+    /// @param oldPkRoot The public root key of the sender's Renegade wallet
+    /// @return The deposit witness hash
+    function buildDepositWitnessHash(PublicRootKey calldata oldPkRoot) internal pure returns (bytes32) {
+        return keccak256(abi.encode(oldPkRoot));
+    }
+
+    // --- Withdrawal --- //
+
+    /// @notice Executes a withdrawal of shares from the darkpool
+    /// @param transfer The transfer to execute
+    function executeWithdrawal(ExternalTransfer calldata transfer) internal {
+        // TODO: Implement withdrawal logic
+    }
+}

--- a/src/libraries/darkpool/WalletOperations.sol
+++ b/src/libraries/darkpool/WalletOperations.sol
@@ -87,7 +87,7 @@ library WalletOperations {
     }
 
     /// @notice Get an ethereum address from a public root key
-    function addressFromRootKey(PublicRootKey memory rootKey) internal view returns (address) {
+    function addressFromRootKey(PublicRootKey memory rootKey) internal pure returns (address) {
         uint256 x = scalarWordsToUint(rootKey.x[0], rootKey.x[1]);
         uint256 y = scalarWordsToUint(rootKey.y[0], rootKey.y[1]);
         // Pack x and y into 64 bytes

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -82,7 +82,7 @@ contract CalldataUtils is TestUtils {
     }
 
     /// @notice Convert a forge wallet to a public root key
-    function forgeWalletToRootKey(Vm.Wallet memory wallet) internal returns (PublicRootKey memory rootKey) {
+    function forgeWalletToRootKey(Vm.Wallet memory wallet) internal pure returns (PublicRootKey memory rootKey) {
         (BN254.ScalarField xLow, BN254.ScalarField xHigh) = uintToScalarWords(wallet.publicKeyX);
         (BN254.ScalarField yLow, BN254.ScalarField yHigh) = uintToScalarWords(wallet.publicKeyY);
         rootKey = PublicRootKey({ x: [xLow, xHigh], y: [yLow, yHigh] });

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -21,7 +21,7 @@ contract TestUtils is Test {
 
     /// @dev Generates a random input modulo the PRIME
     function randomFelt() internal returns (uint256) {
-        return vm.randomUint(0, BN254.R_MOD);
+        return vm.randomUint(0, BN254.R_MOD - 1);
     }
 
     /// @dev Generate a random BN254 scalar field element
@@ -43,7 +43,7 @@ contract TestUtils is Test {
 
     /// @dev Generates a random input between [low, high)
     function randomUint(uint256 low, uint256 high) internal returns (uint256) {
-        return vm.randomUint(low, high);
+        return vm.randomUint(low, high - 1);
     }
 
     /// @dev Generate a random set of wallet shares


### PR DESCRIPTION
### Purpose
This PR adds the initial transfer library in `TransferExecutor`; including only the deposit logic for now. This includes the EIP 712 hashing methods needed to interface with permit2. Withdrawals are left for a follow up.

### Testing
- [x] Unit tests pass