### PR TITLE
test: Darkpool.t.sol: Add tests for deposit and withdrawals

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,4 @@
 [profile.default]
-solc_version = "0.8.20"
 evm_version = "cancun"
 src = "src"
 out = "out"

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,3 +5,5 @@ solidity-stringutils/=lib/foundry-huff/lib/solidity-stringutils/
 stringutils/=lib/foundry-huff/lib/solidity-stringutils/
 solidity-bn254/=lib/solidity-bn254/src/
 permit2/=lib/permit2/src/
+permit2-test/=lib/permit2/test/
+oz-contracts/=lib/openzeppelin-contracts/contracts

--- a/src/libraries/darkpool/ExternalTransfers.sol
+++ b/src/libraries/darkpool/ExternalTransfers.sol
@@ -13,8 +13,8 @@ import {
 } from "../darkpool/Types.sol";
 import { WalletOperations } from "../darkpool/WalletOperations.sol";
 import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
-import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
+import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
 // @title TransferExecutor
 // @notice This library implements the logic for executing external transfers

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -8,6 +8,12 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 /// @dev The type hash for the DepositWitness struct
 bytes32 constant DEPOSIT_WITNESS_TYPEHASH = keccak256("DepositWitness(uint256[4] pkRoot)");
 /// @dev The type string for the DepositWitness struct
+/// @dev We must include the `TokenPermission` type encoding as well as this is concatenated with
+/// @dev the `PermitWitnessTransferFrom` type encoding stub of the form:
+/// @dev `PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,`
+/// @dev So we must prepare our type string to concatenate to the entire type encoding
+/// @dev See:
+/// https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/libraries/PermitHash.sol#L31-L32
 string constant DEPOSIT_WITNESS_TYPE_STRING =
     "DepositWitness witness)DepositWitness(uint256[4] pkRoot)TokenPermissions(address token,uint256 amount)";
 

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -27,6 +27,13 @@ struct ExternalTransfer {
     TransferType transferType;
 }
 
+/// @notice Checks if an ExternalTransfer has zero values
+/// @param transfer The ExternalTransfer to check
+/// @return True if the amount is zero
+function isZero(ExternalTransfer memory transfer) pure returns (bool) {
+    return transfer.amount == 0;
+}
+
 /// @notice The type of transfer
 enum TransferType {
     Deposit,

--- a/src/libraries/darkpool/WalletOperations.sol
+++ b/src/libraries/darkpool/WalletOperations.sol
@@ -71,7 +71,7 @@ library WalletOperations {
         PublicRootKey memory rootKey
     )
         internal
-        view
+        pure
         returns (bool)
     {
         // Split the signature into r, s and v

--- a/src/libraries/darkpool/WalletOperations.sol
+++ b/src/libraries/darkpool/WalletOperations.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.20;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { PublicRootKey } from "./Types.sol";
 import { IHasher } from "../poseidon2/IHasher.sol";
-import { console2 } from "forge-std/console2.sol";
 
 // --- Helpers --- //
 
@@ -54,7 +53,7 @@ library WalletOperations {
         PublicRootKey memory oldRootKey
     )
         internal
-        view
+        pure
         returns (bool)
     {
         // 1. Hash the wallet commitment

--- a/src/libraries/verifier/BN254Helpers.sol
+++ b/src/libraries/verifier/BN254Helpers.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { BN254, Utils as BN254Util } from "solidity-bn254/BN254.sol";
 import { console2 } from "forge-std/console2.sol";
-import { Math } from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import { Math } from "@oz-contracts/contracts/utils/math/Math.sol";
 
 /// @title Helper functions for BN254 curve operations
 /// @notice This library contains utility functions for working with the BN254 curve

--- a/src/libraries/verifier/BN254Helpers.sol
+++ b/src/libraries/verifier/BN254Helpers.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import { BN254, Utils as BN254Util } from "solidity-bn254/BN254.sol";
 import { console2 } from "forge-std/console2.sol";
-import { Math } from "@oz-contracts/contracts/utils/math/Math.sol";
+import { Math } from "oz-contracts/utils/math/Math.sol";
 
 /// @title Helper functions for BN254 curve operations
 /// @notice This library contains utility functions for working with the BN254 curve

--- a/test/Darkpool.t.sol
+++ b/test/Darkpool.t.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { ERC20Mock } from "@oz-contracts/contracts/mocks/token/ERC20Mock.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
 import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
-import { DeployPermit2 } from "permit2/../test/utils/DeployPermit2.sol";
+import { DeployPermit2 } from "permit2-test/utils/DeployPermit2.sol";
 import { Test } from "forge-std/Test.sol";
 import { TestUtils } from "./utils/TestUtils.sol";
 import { CalldataUtils } from "./utils/CalldataUtils.sol";
@@ -81,12 +81,9 @@ contract DarkpoolTest is CalldataUtils {
     /// @notice Test updating a wallet
     function test_updateWallet_validUpdate() public {
         // Setup calldata
-        (
-            bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
-            ValidWalletUpdateStatement memory statement,
-            PlonkProof memory proof
-        ) = updateWalletCalldata(hasher);
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+            updateWalletCalldata(hasher);
+        TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Modify the merkle root to be valid
         BN254.ScalarField currRoot = darkpool.getMerkleRoot();
@@ -99,12 +96,9 @@ contract DarkpoolTest is CalldataUtils {
     /// @notice Test updating a wallet with an invalid Merkle root
     function test_updateWallet_invalidMerkleRoot() public {
         // Setup calldata
-        (
-            bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
-            ValidWalletUpdateStatement memory statement,
-            PlonkProof memory proof
-        ) = updateWalletCalldata(hasher);
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+            updateWalletCalldata(hasher);
+        TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Modify the merkle root to be invalid
         statement.merkleRoot = randomScalar();
@@ -117,12 +111,9 @@ contract DarkpoolTest is CalldataUtils {
     /// @notice Test updating a wallet with a spent nullifier
     function test_updateWallet_spentNullifier() public {
         // Setup calldata
-        (
-            bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
-            ValidWalletUpdateStatement memory statement,
-            PlonkProof memory proof
-        ) = updateWalletCalldata(hasher);
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+            updateWalletCalldata(hasher);
+        TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Modify the merkle root to be valid
         BN254.ScalarField currRoot = darkpool.getMerkleRoot();
@@ -139,12 +130,9 @@ contract DarkpoolTest is CalldataUtils {
     /// @notice Test updating a wallet with an invalid signature
     function test_updateWallet_invalidSignature() public {
         // Setup calldata
-        (
-            bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
-            ValidWalletUpdateStatement memory statement,
-            PlonkProof memory proof
-        ) = updateWalletCalldata(hasher);
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+            updateWalletCalldata(hasher);
+        TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Use the current Merkle root to isolate the signature check directly
         BN254.ScalarField currRoot = darkpool.getMerkleRoot();
@@ -167,9 +155,6 @@ contract DarkpoolTest is CalldataUtils {
         Vm.Wallet memory userWallet = randomEthereumWallet();
         Vm.Wallet memory rootKeyWallet = randomEthereumWallet();
         token1.mint(userWallet.addr, depositAmount);
-        vm.startBroadcast(userWallet.addr);
-        token1.approve(address(permit2), depositAmount);
-        vm.stopBroadcast();
 
         uint256 darkpoolBalanceBefore = token1.balanceOf(address(darkpool));
         uint256 userBalanceBefore = token1.balanceOf(userWallet.addr);
@@ -181,7 +166,7 @@ contract DarkpoolTest is CalldataUtils {
             amount: depositAmount,
             transferType: TransferType.Deposit
         });
-        (bytes memory newSharesCommitmentSig,, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
             generateUpdateWalletCalldata(hasher, transfer, rootKeyWallet);
         statement.merkleRoot = darkpool.getMerkleRoot();
 
@@ -218,7 +203,7 @@ contract DarkpoolTest is CalldataUtils {
             amount: withdrawalAmount,
             transferType: TransferType.Withdrawal
         });
-        (bytes memory newSharesCommitmentSig,, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
             generateUpdateWalletCalldata(hasher, transfer, rootKeyWallet);
         statement.merkleRoot = darkpool.getMerkleRoot();
 

--- a/test/Darkpool.t.sol
+++ b/test/Darkpool.t.sol
@@ -2,13 +2,17 @@
 pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { ERC20Mock } from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
+import { DeployPermit2 } from "permit2/../test/utils/DeployPermit2.sol";
 import { Test } from "forge-std/Test.sol";
 import { TestUtils } from "./utils/TestUtils.sol";
 import { CalldataUtils } from "./utils/CalldataUtils.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { console2 } from "forge-std/console2.sol";
-
+import { Vm } from "forge-std/Vm.sol";
 import { PlonkProof } from "../src/libraries/verifier/Types.sol";
+import { ExternalTransfer, TransferType, TransferAuthorization } from "../src/libraries/darkpool/Types.sol";
 import { Darkpool } from "../src/Darkpool.sol";
 import { NullifierLib } from "../src/libraries/darkpool/NullifierSet.sol";
 import { IHasher } from "../src/libraries/poseidon2/IHasher.sol";
@@ -21,15 +25,29 @@ contract DarkpoolTest is CalldataUtils {
 
     Darkpool public darkpool;
     IHasher public hasher;
+    ERC20Mock public token1;
+    ERC20Mock public token2;
     NullifierLib.NullifierSet private testNullifierSet;
+    IPermit2 public permit2;
 
     function setUp() public {
+        // Deploy a Permit2 instance for testing
+        DeployPermit2 permit2Deployer = new DeployPermit2();
+        permit2 = IPermit2(permit2Deployer.deployPermit2());
+
+        // Deploy mock tokens for testing
+        token1 = new ERC20Mock();
+        token2 = new ERC20Mock();
+
+        // Deploy the darkpool implementation contracts
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
         IVerifier verifier = new TestVerifier();
-        darkpool = new Darkpool(hasher, verifier);
+        darkpool = new Darkpool(hasher, verifier, permit2);
     }
 
-    // --- Library Primitive Tests --- //
+    // ---------------------------
+    // | Library Primitive Tests |
+    // ---------------------------
 
     /// @notice Test the nullifier set
     function test_nullifierSet() public {
@@ -44,7 +62,11 @@ contract DarkpoolTest is CalldataUtils {
         testNullifierSet.spend(nullifier);
     }
 
-    // --- Darkpool Method Tests --- //
+    // -------------------------
+    // | Darkpool Method Tests |
+    // -------------------------
+
+    // --- Create Wallet --- //
 
     /// @notice Test creating a wallet
     function test_createWallet() public {
@@ -52,57 +74,75 @@ contract DarkpoolTest is CalldataUtils {
         darkpool.createWallet(statement, proof);
     }
 
+    // --- Update Wallet --- //
+
     /// @notice Test updating a wallet
     function test_updateWallet_validUpdate() public {
         // Setup calldata
-        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+        (
+            bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
+            ValidWalletUpdateStatement memory statement,
+            PlonkProof memory proof
+        ) = updateWalletCalldata(hasher);
 
         // Modify the merkle root to be valid
         BN254.ScalarField currRoot = darkpool.getMerkleRoot();
         statement.merkleRoot = currRoot;
 
         // Update the wallet
-        darkpool.updateWallet(newSharesCommitmentSig, statement, proof);
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 
     /// @notice Test updating a wallet with an invalid Merkle root
     function test_updateWallet_invalidMerkleRoot() public {
         // Setup calldata
-        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+        (
+            bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
+            ValidWalletUpdateStatement memory statement,
+            PlonkProof memory proof
+        ) = updateWalletCalldata(hasher);
 
         // Modify the merkle root to be invalid
         statement.merkleRoot = randomScalar();
 
         // Should fail
         vm.expectRevert("Invalid Merkle root");
-        darkpool.updateWallet(newSharesCommitmentSig, statement, proof);
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 
     /// @notice Test updating a wallet with a spent nullifier
     function test_updateWallet_spentNullifier() public {
         // Setup calldata
-        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+        (
+            bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
+            ValidWalletUpdateStatement memory statement,
+            PlonkProof memory proof
+        ) = updateWalletCalldata(hasher);
 
         // Modify the merkle root to be valid
         BN254.ScalarField currRoot = darkpool.getMerkleRoot();
         statement.merkleRoot = currRoot;
 
         // First update should succeed
-        darkpool.updateWallet(newSharesCommitmentSig, statement, proof);
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
 
         // Second update with same nullifier should fail
         vm.expectRevert("Nullifier already spent");
-        darkpool.updateWallet(newSharesCommitmentSig, statement, proof);
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 
     /// @notice Test updating a wallet with an invalid signature
     function test_updateWallet_invalidSignature() public {
         // Setup calldata
-        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+        (
+            bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
+            ValidWalletUpdateStatement memory statement,
+            PlonkProof memory proof
+        ) = updateWalletCalldata(hasher);
 
         // Use the current Merkle root to isolate the signature check directly
         BN254.ScalarField currRoot = darkpool.getMerkleRoot();
@@ -114,6 +154,32 @@ contract DarkpoolTest is CalldataUtils {
 
         // Should fail
         vm.expectRevert("Invalid signature");
-        darkpool.updateWallet(newSharesCommitmentSig, statement, proof);
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
+    }
+
+    /// @notice Test updating a wallet with a deposit
+    function test_updateWallet_deposit() public {
+        Vm.Wallet memory userWallet = randomEthereumWallet();
+        ExternalTransfer memory transfer = ExternalTransfer({
+            account: userWallet.addr,
+            mint: address(token1),
+            amount: 100,
+            transferType: TransferType.Deposit
+        });
+
+        // Setup calldata
+        (
+            bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
+            ValidWalletUpdateStatement memory statement,
+            PlonkProof memory proof
+        ) = updateWalletWithExternalTransferCalldata(hasher, transfer);
+        statement.merkleRoot = darkpool.getMerkleRoot();
+
+        // Update the wallet
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
+
+        // Check that the token balance has increased
+        // TODO: Implement this
     }
 }

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.20;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
-import { PermitSignature } from "permit2/../test/utils/PermitSignature.sol";
 import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
-import { IERC20 } from "@oz-contracts/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "oz-contracts/token/ERC20/IERC20.sol";
 import { TestUtils } from "./TestUtils.sol";
 import { PlonkProof } from "../../src/libraries/verifier/Types.sol";
 import { IHasher } from "../../src/libraries/poseidon2/IHasher.sol";
@@ -58,7 +57,6 @@ contract CalldataUtils is TestUtils {
         internal
         returns (
             bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
             ValidWalletUpdateStatement memory statement,
             PlonkProof memory proof
         )
@@ -75,7 +73,6 @@ contract CalldataUtils is TestUtils {
         internal
         returns (
             bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
             ValidWalletUpdateStatement memory statement,
             PlonkProof memory proof
         )
@@ -93,7 +90,6 @@ contract CalldataUtils is TestUtils {
         internal
         returns (
             bytes memory newSharesCommitmentSig,
-            TransferAuthorization memory transferAuthorization,
             ValidWalletUpdateStatement memory statement,
             PlonkProof memory proof
         )
@@ -116,9 +112,6 @@ contract CalldataUtils is TestUtils {
         bytes32 digest = WalletOperations.walletCommitmentDigest(newSharesCommitment);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(rootKeyWallet.privateKey, digest);
         newSharesCommitmentSig = abi.encodePacked(r, s, v);
-
-        // TODO: Add transfer authorization
-        transferAuthorization = emptyTransferAuthorization();
     }
 
     // --------------------
@@ -159,7 +152,9 @@ contract CalldataUtils is TestUtils {
 
         // 1. Approve the permit2 contract
         IERC20 token = IERC20(transfer.mint);
+        vm.startBroadcast(wallet.addr);
         token.approve(address(permit2), transfer.amount);
+        vm.stopBroadcast();
 
         // 2. Generate a permit2 signature
         uint256 nonce = randomUint();

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -172,7 +172,12 @@ contract CalldataUtils is TestUtils {
         bytes32 depositWitnessHash = hashDepositWitness(depositWitness);
 
         bytes memory sig = getPermitWitnessTransferSignature(
-            permit, wallet.privateKey, PERMIT_TRANSFER_FROM_TYPEHASH, depositWitnessHash, permit2.DOMAIN_SEPARATOR()
+            permit,
+            darkpoolAddress,
+            wallet.privateKey,
+            PERMIT_TRANSFER_FROM_TYPEHASH,
+            depositWitnessHash,
+            permit2.DOMAIN_SEPARATOR()
         );
 
         authorization.permit2Nonce = nonce;
@@ -185,6 +190,7 @@ contract CalldataUtils is TestUtils {
     /// @dev if the import is directly from `permit2/test/utils/PermitSignature.sol`
     function getPermitWitnessTransferSignature(
         ISignatureTransfer.PermitTransferFrom memory permit,
+        address receiver,
         uint256 privateKey,
         bytes32 typehash,
         bytes32 witness,
@@ -200,7 +206,7 @@ contract CalldataUtils is TestUtils {
             abi.encodePacked(
                 "\x19\x01",
                 domainSeparator,
-                keccak256(abi.encode(typehash, tokenPermissions, address(this), permit.nonce, permit.deadline, witness))
+                keccak256(abi.encode(typehash, tokenPermissions, receiver, permit.nonce, permit.deadline, witness))
             )
         );
 
@@ -213,6 +219,7 @@ contract CalldataUtils is TestUtils {
         ExternalTransfer memory transfer,
         Vm.Wallet memory wallet
     )
+        internal
         pure
         returns (TransferAuthorization memory authorization)
     {

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -3,16 +3,25 @@ pragma solidity ^0.8.20;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { Vm } from "forge-std/Vm.sol";
+import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
+import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
+import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { TestUtils } from "./TestUtils.sol";
 import { PlonkProof } from "../../src/libraries/verifier/Types.sol";
 import { IHasher } from "../../src/libraries/poseidon2/IHasher.sol";
-import { ExternalTransfer, PublicRootKey, TransferType } from "../../src/libraries/darkpool/Types.sol";
+import {
+    ExternalTransfer,
+    PublicRootKey,
+    TransferType,
+    TransferAuthorization,
+    DepositWitness,
+    publicKeyToUints
+} from "../../src/libraries/darkpool/Types.sol";
 import { uintToScalarWords, WalletOperations } from "../../src/libraries/darkpool/WalletOperations.sol";
 import { ValidWalletCreateStatement, ValidWalletUpdateStatement } from "../../src/libraries/darkpool/PublicInputs.sol";
-import { console2 } from "forge-std/console2.sol";
 
-// Utilities for generating darkpool calldata
-
+/// @title Calldata Utils
+/// @notice Utilities for generating darkpool calldata
 contract CalldataUtils is TestUtils {
     /// @dev The first testing address
     address public constant DUMMY_ADDRESS = address(0x1);
@@ -40,6 +49,24 @@ contract CalldataUtils is TestUtils {
         internal
         returns (
             bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
+            ValidWalletUpdateStatement memory statement,
+            PlonkProof memory proof
+        )
+    {
+        ExternalTransfer memory transfer = emptyExternalTransfer();
+        return updateWalletWithExternalTransferCalldata(hasher, transfer);
+    }
+
+    /// @notice Generate calldata for a wallet update with a given external transfer
+    function updateWalletWithExternalTransferCalldata(
+        IHasher hasher,
+        ExternalTransfer memory transfer
+    )
+        internal
+        returns (
+            bytes memory newSharesCommitmentSig,
+            TransferAuthorization memory transferAuthorization,
             ValidWalletUpdateStatement memory statement,
             PlonkProof memory proof
         )
@@ -50,7 +77,7 @@ contract CalldataUtils is TestUtils {
             newPublicShares: randomWalletShares(),
             newPrivateShareCommitment: randomScalar(),
             merkleRoot: randomScalar(),
-            externalTransfer: emptyExternalTransfer(),
+            externalTransfer: transfer,
             oldPkRoot: forgeWalletToRootKey(rootKeyWallet)
         });
         proof = dummyPlonkProof();
@@ -63,16 +90,74 @@ contract CalldataUtils is TestUtils {
         bytes32 digest = WalletOperations.walletCommitmentDigest(newSharesCommitment);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(rootKeyWallet.privateKey, digest);
         newSharesCommitmentSig = abi.encodePacked(r, s, v);
+
+        // TODO: Add transfer authorization
+        transferAuthorization = emptyTransferAuthorization();
     }
 
-    // ------------------
-    // | Calldata Types |
-    // ------------------
+    // --------------------
+    // | Calldata Helpers |
+    // --------------------
 
     /// @notice Generate an empty external transfer
     function emptyExternalTransfer() internal pure returns (ExternalTransfer memory transfer) {
         transfer =
             ExternalTransfer({ account: address(0), mint: address(0), amount: 0, transferType: TransferType.Deposit });
+    }
+
+    /// @notice Generate empty transfer authorization
+    function emptyTransferAuthorization() internal pure returns (TransferAuthorization memory authorization) {
+        authorization = TransferAuthorization({
+            permit2Nonce: 0,
+            permit2Deadline: 0,
+            permit2Signature: bytes(""),
+            externalTransferSignature: bytes("")
+        });
+    }
+
+    /// @notice Authorize a deposit
+    function authorizeDeposit(
+        ExternalTransfer memory transfer,
+        PublicRootKey memory oldPkRoot,
+        address darkpoolAddress,
+        IPermit2 permit2,
+        Vm.Wallet memory wallet
+    )
+        internal
+        returns (TransferAuthorization memory authorization)
+    {
+        // Default to empty transfer auth, we only fill in the deposit info
+        authorization = emptyTransferAuthorization();
+
+        // 1. Approve the permit2 contract
+        IERC20 token = IERC20(transfer.mint);
+        token.approve(address(permit2), transfer.amount);
+
+        // 2. Generate a permit2 signature
+        uint256 nonce = randomUint();
+        uint256 deadline = block.timestamp + 1 days;
+        ISignatureTransfer.TokenPermissions memory tokenPermissions =
+            ISignatureTransfer.TokenPermissions({ token: transfer.mint, amount: transfer.amount });
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            ISignatureTransfer.PermitTransferFrom({ permitted: tokenPermissions, nonce: nonce, deadline: deadline });
+        DepositWitness memory depositWitness = DepositWitness({ pkRoot: publicKeyToUints(oldPkRoot) });
+    }
+
+    /// @notice Authorize a withdrawal
+    function authorizeWithdrawal(
+        ExternalTransfer memory transfer,
+        Vm.Wallet memory wallet
+    )
+        internal
+        returns (TransferAuthorization memory authorization)
+    {
+        // Default to empty transfer auth, we only fill in the withdrawal signature
+        authorization = emptyTransferAuthorization();
+
+        // Sign the transfer, this is sufficient for a withdrawal
+        bytes32 digest = keccak256(abi.encode(transfer));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, digest);
+        authorization.externalTransferSignature = abi.encodePacked(r, s, v);
     }
 
     /// @notice Generate a random root key

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -36,6 +36,11 @@ contract TestUtils is Test {
         return point;
     }
 
+    /// @dev Generates a random uint256
+    function randomUint() internal returns (uint256) {
+        return vm.randomUint();
+    }
+
     /// @dev Generates a random input between [0, high)
     function randomUint(uint256 high) internal returns (uint256) {
         return TestUtils.randomUint(0, high);

--- a/test/utils/VerifierTestUtils.sol
+++ b/test/utils/VerifierTestUtils.sol
@@ -15,7 +15,7 @@ import {
 import { console2 } from "forge-std/console2.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { BN254Helpers } from "../../src/libraries/verifier/BN254Helpers.sol";
-import { Strings } from "openzeppelin-contracts/contracts/utils/Strings.sol";
+import { Strings } from "@oz-contracts/contracts/utils/Strings.sol";
 
 contract VerifierTestUtils is TestUtils {
     // ---------

--- a/test/utils/VerifierTestUtils.sol
+++ b/test/utils/VerifierTestUtils.sol
@@ -15,7 +15,7 @@ import {
 import { console2 } from "forge-std/console2.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { BN254Helpers } from "../../src/libraries/verifier/BN254Helpers.sol";
-import { Strings } from "@oz-contracts/contracts/utils/Strings.sol";
+import { Strings } from "oz-contracts/utils/Strings.sol";
 
 contract VerifierTestUtils is TestUtils {
     // ---------


### PR DESCRIPTION
### Purpose
This PR adds tests for deposits and withdrawals via `updateWallet`.

For deposits, this PR adds helpers to generate permit2 signatures over the deposit witness -- in our case the previous root key of the wallet.

For withdrawals, this PR adds helpers to generate K256 signatures over the _abi encoded_ transfer struct. This differs slightly from the stylus implementation which postcard serializes the transfer struct. This will need to be resolved client side.

### Testing
- [x] All unit tests pass