### PR TITLE
libraries: darkpool: Add skeleton for match settlement verification

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -7,3 +7,4 @@ solidity-bn254/=lib/solidity-bn254/src/
 permit2/=lib/permit2/src/
 permit2-test/=lib/permit2/test/
 oz-contracts/=lib/openzeppelin-contracts/contracts
+renegade/=src

--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -125,4 +125,9 @@ contract Darkpool {
             );
         }
     }
+
+    /// @notice Settle a match in the darkpool
+    function processMatchSettle() public {
+        //
+    }
 }

--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -5,8 +5,10 @@ import { PlonkProof, VerificationKey } from "./libraries/verifier/Types.sol";
 import {
     ValidWalletCreateStatement,
     ValidWalletUpdateStatement,
+    ValidMatchSettleStatement,
     StatementSerializer
 } from "./libraries/darkpool/PublicInputs.sol";
+import { PartyMatchPayload, MatchProofs } from "./libraries/darkpool/Types.sol";
 import { VerificationKeys } from "./libraries/darkpool/VerificationKeys.sol";
 import { IVerifier } from "./libraries/verifier/IVerifier.sol";
 import { VerifierCore } from "./libraries/verifier/VerifierCore.sol";
@@ -14,6 +16,7 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 
 using StatementSerializer for ValidWalletCreateStatement;
 using StatementSerializer for ValidWalletUpdateStatement;
+using StatementSerializer for ValidMatchSettleStatement;
 
 /// @title PlonK Verifier with the Jellyfish-style arithmetization
 /// @notice The methods on this contract are darkpool-specific
@@ -50,5 +53,24 @@ contract Verifier is IVerifier {
         VerificationKey memory vk = abi.decode(VerificationKeys.VALID_WALLET_UPDATE_VKEY, (VerificationKey));
         BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
         return VerifierCore.verify(proof, publicInputs, vk);
+    }
+
+    /// @notice Verify a match bundle
+    /// @param party0MatchPayload The payload for the first party
+    /// @param party1MatchPayload The payload for the second party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE`
+    /// @param proofs The proofs for the match, including two sets of validity proofs and a settlement proof
+    /// @return True if the match bundle is valid, false otherwise
+    function verifyMatchBundle(
+        PartyMatchPayload calldata party0MatchPayload,
+        PartyMatchPayload calldata party1MatchPayload,
+        ValidMatchSettleStatement calldata matchSettleStatement,
+        MatchProofs calldata proofs
+    )
+        external
+        view
+        returns (bool)
+    {
+        return false;
     }
 }

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -78,6 +78,22 @@ function hashDepositWitness(DepositWitness memory witness) pure returns (bytes32
     return keccak256(abi.encode(DEPOSIT_WITNESS_TYPEHASH, pkRootHash));
 }
 
+// --------------------
+// | Settlement Types |
+// --------------------
+
+/// @notice A set of indices into a settlement party's wallet for the receive balance
+struct OrderSettlementIndices {
+    /// @dev The index of the balance holding the mint which teh wallet will
+    /// @dev sell in a match
+    uint256 balanceSend;
+    /// @dev The index of the balance holding the mint which the wallet will
+    /// @dev buy in a match
+    uint256 balanceReceive;
+    /// @dev the index of the order that is matched in the wallet
+    uint256 order;
+}
+
 // ------------
 // | Keychain |
 // ------------

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.0;
 // This file contains the types used in the darkpool
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { ValidCommitmentsStatement, ValidReblindStatement } from "./PublicInputs.sol";
+import { PlonkProof } from "../verifier/Types.sol";
 
 /// @dev The type hash for the DepositWitness struct
 bytes32 constant DEPOSIT_WITNESS_TYPEHASH = keccak256("DepositWitness(uint256[4] pkRoot)");
@@ -81,6 +83,30 @@ function hashDepositWitness(DepositWitness memory witness) pure returns (bytes32
 // --------------------
 // | Settlement Types |
 // --------------------
+
+/// @title PartyMatchPayload
+/// @notice Contains the statement types for a single party's validity proofs in a match
+struct PartyMatchPayload {
+    /// @dev The statement types for the `VALID COMMITMENTS` proof
+    ValidCommitmentsStatement validCommitmentsStatement;
+    /// @dev The statement types for the `VALID REBLIND` proof
+    ValidReblindStatement validReblindStatement;
+}
+
+/// @title MatchProofs
+/// @notice Contains the proofs for a match between two parties in the darkpool
+struct MatchProofs {
+    /// @dev The first party's proof of `VALID COMMITMENTS`
+    PlonkProof validCommitments0;
+    /// @dev The first party's proof of `VALID REBLIND`
+    PlonkProof validReblind0;
+    /// @dev The second party's proof of `VALID COMMITMENTS`
+    PlonkProof validCommitments1;
+    /// @dev The second party's proof of `VALID REBLIND`
+    PlonkProof validReblind1;
+    /// @dev The proof of `VALID MATCH SETTLE`
+    PlonkProof validMatchSettle;
+}
 
 /// @notice A set of indices into a settlement party's wallet for the receive balance
 struct OrderSettlementIndices {

--- a/src/libraries/merkle/MerkleTree.sol
+++ b/src/libraries/merkle/MerkleTree.sol
@@ -5,7 +5,6 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 import { IHasher } from "../poseidon2/IHasher.sol";
 import { DarkpoolConstants } from "../darkpool/Constants.sol";
 import { MerkleZeros } from "./MerkleZeros.sol";
-import { console2 } from "forge-std/console2.sol";
 
 /// @title MerkleTreeLib
 /// @notice Library for Merkle tree operations

--- a/src/libraries/verifier/BN254Helpers.sol
+++ b/src/libraries/verifier/BN254Helpers.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { BN254, Utils as BN254Util } from "solidity-bn254/BN254.sol";
-import { console2 } from "forge-std/console2.sol";
 import { Math } from "oz-contracts/utils/math/Math.sol";
 
 /// @title Helper functions for BN254 curve operations

--- a/src/libraries/verifier/IVerifier.sol
+++ b/src/libraries/verifier/IVerifier.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.0;
 
 import { PlonkProof } from "./Types.sol";
-import { ValidWalletCreateStatement, ValidWalletUpdateStatement } from "../darkpool/PublicInputs.sol";
+import {
+    ValidWalletCreateStatement,
+    ValidWalletUpdateStatement,
+    ValidMatchSettleStatement
+} from "../darkpool/PublicInputs.sol";
+import { PartyMatchPayload, MatchProofs } from "../darkpool/Types.sol";
 
 interface IVerifier {
     /// @notice Verify a proof of `VALID WALLET CREATE`
@@ -10,8 +15,8 @@ interface IVerifier {
     /// @param statement The public inputs to the proof
     /// @return True if the proof is valid, false otherwise
     function verifyValidWalletCreate(
-        ValidWalletCreateStatement memory statement,
-        PlonkProof memory proof
+        ValidWalletCreateStatement calldata statement,
+        PlonkProof calldata proof
     )
         external
         view
@@ -22,8 +27,24 @@ interface IVerifier {
     /// @param statement The public inputs to the proof
     /// @return True if the proof is valid, false otherwise
     function verifyValidWalletUpdate(
-        ValidWalletUpdateStatement memory statement,
-        PlonkProof memory proof
+        ValidWalletUpdateStatement calldata statement,
+        PlonkProof calldata proof
+    )
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a match bundle
+    /// @param party0MatchPayload The payload for the first party
+    /// @param party1MatchPayload The payload for the second party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE`
+    /// @param proofs The proofs for the match, including two sets of validity proofs and a settlement proof
+    /// @return True if the match bundle is valid, false otherwise
+    function verifyMatchBundle(
+        PartyMatchPayload calldata party0MatchPayload,
+        PartyMatchPayload calldata party1MatchPayload,
+        ValidMatchSettleStatement calldata matchSettleStatement,
+        MatchProofs calldata proofs
     )
         external
         view

--- a/src/libraries/verifier/ProofLinking.sol
+++ b/src/libraries/verifier/ProofLinking.sol
@@ -8,7 +8,6 @@ import { TranscriptLib, Transcript } from "./Transcript.sol";
 import { ProofLinkingArgument, OpeningElements, LinkingProof, ProofLinkingVK } from "./Types.sol";
 import { BN254Helpers } from "./BN254Helpers.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { console2 } from "forge-std/console2.sol";
 
 library ProofLinkingCore {
     using TranscriptLib for Transcript;

--- a/src/libraries/verifier/Transcript.sol
+++ b/src/libraries/verifier/Transcript.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { BN254Helpers } from "./BN254Helpers.sol";
-import { console2 } from "forge-std/console2.sol";
 import { NUM_WIRE_TYPES, NUM_SELECTORS } from "./Types.sol";
 
 // --- Hash & Transcript Constants --- //

--- a/test/BN254Helpers.t.sol
+++ b/test/BN254Helpers.t.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import {Test} from "forge-std/Test.sol";
-import {TestUtils} from "./utils/TestUtils.sol";
-import {BN254} from "solidity-bn254/BN254.sol";
-import {BN254Helpers} from "../src/libraries/verifier/BN254Helpers.sol";
-import {console2} from "forge-std/console2.sol";
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "./utils/TestUtils.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { BN254Helpers } from "../src/libraries/verifier/BN254Helpers.sol";
 
 contract BN254HelpersTest is TestUtils {
     struct RootOfUnityTest {

--- a/test/Merkle.t.sol
+++ b/test/Merkle.t.sol
@@ -6,7 +6,6 @@ import { Test } from "forge-std/Test.sol";
 import { console } from "forge-std/console.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { TestUtils } from "./utils/TestUtils.sol";
-import { console2 } from "forge-std/console2.sol";
 import { IHasher } from "../src/libraries/poseidon2/IHasher.sol";
 import { MerkleTreeLib } from "../src/libraries/merkle/MerkleTree.sol";
 import { MerkleZeros } from "../src/libraries/merkle/MerkleZeros.sol";

--- a/test/Transcript.t.sol
+++ b/test/Transcript.t.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache
 pragma solidity ^0.8.0;
 
-import {Test} from "forge-std/Test.sol";
-import {BN254} from "solidity-bn254/BN254.sol";
-import {BN254Helpers} from "../src/libraries/verifier/BN254Helpers.sol";
-import {Transcript, TranscriptLib} from "../src/libraries/verifier/Transcript.sol";
-import {TestUtils} from "./utils/TestUtils.sol";
-import {console2} from "forge-std/console2.sol";
+import { Test } from "forge-std/Test.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { BN254Helpers } from "../src/libraries/verifier/BN254Helpers.sol";
+import { Transcript, TranscriptLib } from "../src/libraries/verifier/Transcript.sol";
+import { TestUtils } from "./utils/TestUtils.sol";
 
 /// @title Transcript Test Contract
 /// @notice Test contract for verifying the functionality of the Fiat-Shamir transcript

--- a/test/Verifier.t.sol
+++ b/test/Verifier.t.sol
@@ -15,7 +15,6 @@ import {
 } from "../src/libraries/verifier/Types.sol";
 import { ProofLinkingCore } from "../src/libraries/verifier/ProofLinking.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { console2 } from "forge-std/console2.sol";
 
 contract VerifierTest is VerifierTestUtils {
     TestUtils public testUtils;

--- a/test/darkpool/CreateWallet.t.sol
+++ b/test/darkpool/CreateWallet.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
+import { ValidWalletCreateStatement } from "renegade/libraries/darkpool/PublicInputs.sol";
+import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
+
+contract CreateWalletTest is DarkpoolTestBase {
+    // --- Create Wallet --- //
+
+    /// @notice Test creating a wallet
+    function test_createWallet() public {
+        (ValidWalletCreateStatement memory statement, PlonkProof memory proof) = createWalletCalldata();
+        darkpool.createWallet(statement, proof);
+    }
+}

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
+import { DeployPermit2 } from "permit2-test/utils/DeployPermit2.sol";
+import { Test } from "forge-std/Test.sol";
+import { TestUtils } from "../utils/TestUtils.sol";
+import { CalldataUtils } from "../utils/CalldataUtils.sol";
+import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
+import { Vm } from "forge-std/Vm.sol";
+import {
+    ExternalTransfer, TransferType, TransferAuthorization, PublicRootKey
+} from "renegade/libraries/darkpool/Types.sol";
+import { TestVerifier } from "../test-contracts/TestVerifier.sol";
+import { Darkpool } from "renegade/Darkpool.sol";
+import { NullifierLib } from "renegade/libraries/darkpool/NullifierSet.sol";
+import { WalletOperations } from "renegade/libraries/darkpool/WalletOperations.sol";
+import { IHasher } from "renegade/libraries/poseidon2/IHasher.sol";
+import { IVerifier } from "renegade/libraries/verifier/IVerifier.sol";
+import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
+
+contract DarkpoolTestBase is CalldataUtils {
+    using NullifierLib for NullifierLib.NullifierSet;
+
+    Darkpool public darkpool;
+    IHasher public hasher;
+    NullifierLib.NullifierSet private testNullifierSet;
+    IPermit2 public permit2;
+    ERC20Mock public token1;
+    ERC20Mock public token2;
+
+    function setUp() public {
+        // Deploy a Permit2 instance for testing
+        DeployPermit2 permit2Deployer = new DeployPermit2();
+        permit2 = IPermit2(permit2Deployer.deployPermit2());
+
+        // Deploy mock tokens for testing
+        token1 = new ERC20Mock();
+        token2 = new ERC20Mock();
+
+        // Deploy the darkpool implementation contracts
+        hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
+        IVerifier verifier = new TestVerifier();
+        darkpool = new Darkpool(hasher, verifier, permit2);
+    }
+
+    // ---------------------------
+    // | Library Primitive Tests |
+    // ---------------------------
+
+    /// @notice Test the nullifier set
+    function test_nullifierSet() public {
+        BN254.ScalarField nullifier = BN254.ScalarField.wrap(randomFelt());
+        testNullifierSet.spend(nullifier); // Should succeed
+
+        // Check that the nullifier is spent
+        assertEq(testNullifierSet.isSpent(nullifier), true);
+
+        // Should fail
+        vm.expectRevert("Nullifier already spent");
+        testNullifierSet.spend(nullifier);
+    }
+}

--- a/test/darkpool/UpdateWallet.t.sol
+++ b/test/darkpool/UpdateWallet.t.sol
@@ -2,80 +2,15 @@
 pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
-import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
-import { DeployPermit2 } from "permit2-test/utils/DeployPermit2.sol";
-import { Test } from "forge-std/Test.sol";
-import { TestUtils } from "./utils/TestUtils.sol";
-import { CalldataUtils } from "./utils/CalldataUtils.sol";
-import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { PlonkProof } from "../src/libraries/verifier/Types.sol";
+import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
 import {
     ExternalTransfer, TransferType, TransferAuthorization, PublicRootKey
-} from "../src/libraries/darkpool/Types.sol";
-import { Darkpool } from "../src/Darkpool.sol";
-import { NullifierLib } from "../src/libraries/darkpool/NullifierSet.sol";
-import { WalletOperations } from "../src/libraries/darkpool/WalletOperations.sol";
-import { IHasher } from "../src/libraries/poseidon2/IHasher.sol";
-import { IVerifier } from "../src/libraries/verifier/IVerifier.sol";
-import { TestVerifier } from "./test-contracts/TestVerifier.sol";
-import { ValidWalletCreateStatement, ValidWalletUpdateStatement } from "../src/libraries/darkpool/PublicInputs.sol";
+} from "renegade/libraries/darkpool/Types.sol";
+import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
+import { ValidWalletUpdateStatement } from "renegade/libraries/darkpool/PublicInputs.sol";
 
-contract DarkpoolTest is CalldataUtils {
-    using NullifierLib for NullifierLib.NullifierSet;
-
-    Darkpool public darkpool;
-    IHasher public hasher;
-    ERC20Mock public token1;
-    ERC20Mock public token2;
-    NullifierLib.NullifierSet private testNullifierSet;
-    IPermit2 public permit2;
-
-    function setUp() public {
-        // Deploy a Permit2 instance for testing
-        DeployPermit2 permit2Deployer = new DeployPermit2();
-        permit2 = IPermit2(permit2Deployer.deployPermit2());
-
-        // Deploy mock tokens for testing
-        token1 = new ERC20Mock();
-        token2 = new ERC20Mock();
-
-        // Deploy the darkpool implementation contracts
-        hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
-        IVerifier verifier = new TestVerifier();
-        darkpool = new Darkpool(hasher, verifier, permit2);
-    }
-
-    // ---------------------------
-    // | Library Primitive Tests |
-    // ---------------------------
-
-    /// @notice Test the nullifier set
-    function test_nullifierSet() public {
-        BN254.ScalarField nullifier = BN254.ScalarField.wrap(randomFelt());
-        testNullifierSet.spend(nullifier); // Should succeed
-
-        // Check that the nullifier is spent
-        assertEq(testNullifierSet.isSpent(nullifier), true);
-
-        // Should fail
-        vm.expectRevert("Nullifier already spent");
-        testNullifierSet.spend(nullifier);
-    }
-
-    // -------------------------
-    // | Darkpool Method Tests |
-    // -------------------------
-
-    // --- Create Wallet --- //
-
-    /// @notice Test creating a wallet
-    function test_createWallet() public {
-        (ValidWalletCreateStatement memory statement, PlonkProof memory proof) = createWalletCalldata();
-        darkpool.createWallet(statement, proof);
-    }
-
+contract UpdateWalletTest is DarkpoolTestBase {
     // --- Update Wallet --- //
 
     /// @notice Test updating a wallet

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -192,7 +192,7 @@ contract CalldataUtils is TestUtils {
         bytes32 domainSeparator
     )
         internal
-        view
+        pure
         returns (bytes memory sig)
     {
         bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));

--- a/test/utils/VerifierTestUtils.sol
+++ b/test/utils/VerifierTestUtils.sol
@@ -12,7 +12,6 @@ import {
     ProofLinkingArgument,
     LinkingProof
 } from "../../src/libraries/verifier/Types.sol";
-import { console2 } from "forge-std/console2.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { BN254Helpers } from "../../src/libraries/verifier/BN254Helpers.sol";
 import { Strings } from "oz-contracts/utils/Strings.sol";


### PR DESCRIPTION
### Purpose
This PR scaffolds the types and interfaces for the `processMatchSettle` method on the darkpool. This method receives the validity proofs of two parties, a proof of `VALID MATCH SETTLE`, and proof links between the parties' proofs and the settlement proof. This method batch verifies all proofs, then updates the Merkle and nullifier state appropriately.

### Testing
- [x] Unit tests pass