### PR TITLE
Darkpool.sol: Implement `processMatchSettle`

### DIFF
--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -120,6 +120,14 @@ struct OrderSettlementIndices {
     uint256 order;
 }
 
+/// @notice Return whether two sets of indices are equal
+/// @param a The first set of indices
+/// @param b The second set of indices
+/// @return True if the indices are equal, false otherwise
+function indicesEqual(OrderSettlementIndices memory a, OrderSettlementIndices memory b) pure returns (bool) {
+    return a.balanceSend == b.balanceSend && a.balanceReceive == b.balanceReceive && a.order == b.order;
+}
+
 // ------------
 // | Keychain |
 // ------------

--- a/test/darkpool/UpdateWallet.t.sol
+++ b/test/darkpool/UpdateWallet.t.sol
@@ -39,7 +39,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
         statement.merkleRoot = randomScalar();
 
         // Should fail
-        vm.expectRevert("Invalid Merkle root");
+        vm.expectRevert("Merkle root not in history");
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -40,14 +40,14 @@ contract TestVerifier is IVerifier {
         view
         returns (bool)
     {
-        bool _res = verifier.verifyValidWalletCreate(statement, proof);
+        verifier.verifyValidWalletCreate(statement, proof);
         return true;
     }
 
     /// @notice Verify a proof of `VALID WALLET UPDATE`
     /// @param statement The public inputs to the proof
     /// @param proof The proof to verify
-    /// @return True if the proof is valid, false otherwise
+    /// @return True always, regardless of the proof
     function verifyValidWalletUpdate(
         ValidWalletUpdateStatement calldata statement,
         PlonkProof calldata proof
@@ -56,7 +56,7 @@ contract TestVerifier is IVerifier {
         view
         returns (bool)
     {
-        bool _res = verifier.verifyValidWalletUpdate(statement, proof);
+        verifier.verifyValidWalletUpdate(statement, proof);
         return true;
     }
 
@@ -76,7 +76,7 @@ contract TestVerifier is IVerifier {
         view
         returns (bool)
     {
-        bool _res = verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs);
+        verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs);
         return true;
     }
 }

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -106,7 +106,7 @@ contract CalldataUtils is TestUtils {
 
         // Sign the new shares commitment
         BN254.ScalarField newSharesCommitment = WalletOperations.computeWalletCommitment(
-            statement.newPublicShares, statement.newPrivateShareCommitment, hasher
+            statement.newPrivateShareCommitment, statement.newPublicShares, hasher
         );
 
         bytes32 digest = WalletOperations.walletCommitmentDigest(newSharesCommitment);


### PR DESCRIPTION
### Purpose
This PR implements the logic for the `processMatchSettle` method in the darkpool. This follows the skeleton referenced in #55. 

### Todo
- [ ] Add protocol fees
- [ ] Add match settle proof linking
- [ ] Testing for match settlement

### Testing
- [x] All unit tests pass