### PR TITLE
test: darkpool: SettleMatch.t.sol: Add match settlement tests

### DIFF
--- a/src/libraries/darkpool/Constants.sol
+++ b/src/libraries/darkpool/Constants.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.0;
 /// @title Darkpool Constants
 /// @notice Constants used in the darkpool
 library DarkpoolConstants {
+    /// @notice The maximum number of orders in a wallet
+    uint256 constant MAX_ORDERS = 4;
+    /// @notice The maximum number of balances in a wallet
+    uint256 constant MAX_BALANCES = 10;
     /// @notice The number of shares in a wallet
     uint256 constant N_WALLET_SHARES = 70;
     /// @notice The depth of the Merkle tree

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -31,6 +31,10 @@ contract DarkpoolTestBase is CalldataUtils {
     ERC20Mock public token1;
     ERC20Mock public token2;
 
+    bytes constant INVALID_NULLIFIER_REVERT_STRING = "Nullifier already spent";
+    bytes constant INVALID_ROOT_REVERT_STRING = "Merkle root not in history";
+    bytes constant INVALID_SIGNATURE_REVERT_STRING = "Invalid signature";
+
     function setUp() public {
         // Deploy a Permit2 instance for testing
         DeployPermit2 permit2Deployer = new DeployPermit2();

--- a/test/darkpool/SettleMatch.t.sol
+++ b/test/darkpool/SettleMatch.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { Test } from "forge-std/Test.sol";
+import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
+import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
+import { PartyMatchPayload, MatchProofs, TransferAuthorization } from "renegade/libraries/darkpool/Types.sol";
+import { ValidWalletUpdateStatement, ValidMatchSettleStatement } from "renegade/libraries/darkpool/PublicInputs.sol";
+
+contract SettleMatchTest is DarkpoolTestBase {
+    // --- Settle Match --- //
+
+    /// @notice Test settling a match
+    function test_settleMatch_validMatch() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory party0Payload,
+            PartyMatchPayload memory party1Payload,
+            ValidMatchSettleStatement memory statement,
+            MatchProofs memory proofs
+        ) = settleMatchCalldata(merkleRoot);
+
+        // Process the match
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+
+        // Check that the nullifiers are used
+        BN254.ScalarField nullifier0 = party0Payload.validReblindStatement.originalSharesNullifier;
+        BN254.ScalarField nullifier1 = party1Payload.validReblindStatement.originalSharesNullifier;
+        assertEq(darkpool.nullifierSpent(nullifier0), true);
+        assertEq(darkpool.nullifierSpent(nullifier1), true);
+    }
+
+    /// @notice Test settling a match in which the nullifier of one party is spent
+    function test_settleMatch_spentNullifier() public {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        BN254.ScalarField nullifier = randomScalar();
+
+        // Update a wallet using the nullifier
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+            updateWalletCalldata(hasher);
+        statement.previousNullifier = nullifier;
+        statement.merkleRoot = merkleRoot;
+        TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
+
+        // Setup calldata
+        (
+            PartyMatchPayload memory party0Payload,
+            PartyMatchPayload memory party1Payload,
+            ValidMatchSettleStatement memory matchStatement,
+            MatchProofs memory matchProofs
+        ) = settleMatchCalldata(merkleRoot);
+
+        if (vm.randomBool()) {
+            // Party 0 uses the invalid nullifier
+            party0Payload.validReblindStatement.originalSharesNullifier = nullifier;
+        } else {
+            // Party 1 uses the invalid nullifier
+            party1Payload.validReblindStatement.originalSharesNullifier = nullifier;
+        }
+
+        // Should fail
+        vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
+        darkpool.processMatchSettle(party0Payload, party1Payload, matchStatement, matchProofs);
+    }
+
+    /// @notice Test settling a match in which one party is using an invalid Merkle root
+    function test_settleMatch_invalidMerkleRoot() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory party0Payload,
+            PartyMatchPayload memory party1Payload,
+            ValidMatchSettleStatement memory statement,
+            MatchProofs memory proofs
+        ) = settleMatchCalldata(merkleRoot);
+
+        if (vm.randomBool()) {
+            // Party 0 has an invalid Merkle root
+            party0Payload.validReblindStatement.merkleRoot = randomScalar();
+        } else {
+            // Party 1 has an invalid Merkle root
+            party1Payload.validReblindStatement.merkleRoot = randomScalar();
+        }
+
+        // Should fail
+        vm.expectRevert(INVALID_ROOT_REVERT_STRING);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+    }
+
+    /// @notice Test settling a match in which one party's settlement indices are inconsistent
+    function test_settleMatch_inconsistentIndices() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory party0Payload,
+            PartyMatchPayload memory party1Payload,
+            ValidMatchSettleStatement memory statement,
+            MatchProofs memory proofs
+        ) = settleMatchCalldata(merkleRoot);
+
+        bytes memory revertString;
+        if (vm.randomBool()) {
+            // Party 0 has an invalid settlement indices
+            party0Payload.validCommitmentsStatement.indices = randomOrderSettlementIndices();
+            revertString = "Invalid party 0 order settlement indices";
+        } else {
+            // Party 1 has an invalid settlement indices
+            party1Payload.validCommitmentsStatement.indices = randomOrderSettlementIndices();
+            revertString = "Invalid party 1 order settlement indices";
+        }
+
+        // Should fail
+        vm.expectRevert(revertString);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+    }
+}

--- a/test/darkpool/UpdateWallet.t.sol
+++ b/test/darkpool/UpdateWallet.t.sol
@@ -26,6 +26,10 @@ contract UpdateWalletTest is DarkpoolTestBase {
 
         // Update the wallet
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
+
+        // Check that the nullifier is used
+        BN254.ScalarField nullifier = statement.previousNullifier;
+        assertEq(darkpool.nullifierSpent(nullifier), true);
     }
 
     /// @notice Test updating a wallet with an invalid Merkle root
@@ -39,7 +43,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
         statement.merkleRoot = randomScalar();
 
         // Should fail
-        vm.expectRevert("Merkle root not in history");
+        vm.expectRevert(INVALID_ROOT_REVERT_STRING);
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 
@@ -58,7 +62,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
 
         // Second update with same nullifier should fail
-        vm.expectRevert("Nullifier already spent");
+        vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 
@@ -78,7 +82,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
         newSharesCommitmentSig[randIdx] = randomByte();
 
         // Should fail
-        vm.expectRevert("Invalid signature");
+        vm.expectRevert(INVALID_SIGNATURE_REVERT_STRING);
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
     }
 


### PR DESCRIPTION
### Purpose
This PR adds a suite of tests for the `processMatchSettle` method on the darkpool contract. These test all assertions by the contract.

### Todo
- [ ] Protocol fees in match settlement
- [ ] Proof linking for settlement <-> validity proofs

### Testing
- [x] All unit tests pass