### PR TITLE
Darkpool.sol: Add protocol fee to darkpool storage

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -28,6 +28,13 @@ using MerkleTreeLib for MerkleTreeLib.MerkleTree;
 using NullifierLib for NullifierLib.NullifierSet;
 
 contract Darkpool {
+    /// @notice The protocol fee rate for the darkpool
+    /// @dev This is the fixed point representation of a real number between 0 and 1.
+    /// @dev To convert to its floating point representation, divide by the fixed point
+    /// @dev precision, i.e. `fee = protocolFeeRate / FIXED_POINT_PRECISION`.
+    /// @dev The current precision is `2 ** 63`.
+    uint256 public protocolFeeRate;
+
     /// @notice The hasher for the darkpool
     IHasher public hasher;
     /// @notice The verifier for the darkpool
@@ -47,7 +54,8 @@ contract Darkpool {
     /// @param hasher_ The hasher for the darkpool
     /// @param verifier_ The verifier for the darkpool
     /// @param permit2_ The Permit2 contract instance for handling deposits
-    constructor(IHasher hasher_, IVerifier verifier_, IPermit2 permit2_) {
+    constructor(uint256 protocolFeeRate_, IHasher hasher_, IVerifier verifier_, IPermit2 permit2_) {
+        protocolFeeRate = protocolFeeRate_;
         hasher = hasher_;
         verifier = verifier_;
         permit2 = permit2_;
@@ -161,7 +169,8 @@ contract Darkpool {
         require(party0ValidIndices, "Invalid party 0 order settlement indices");
         require(party1ValidIndices, "Invalid party 1 order settlement indices");
 
-        // 3. TODO: Validate the protocol fee rate used in the settlement
+        // 3. Validate the protocol fee rate used in the settlement
+        require(matchSettleStatement.protocolFeeRate == protocolFeeRate, "Invalid protocol fee rate");
 
         // 4. Insert the new shares into the Merkle tree
         WalletOperations.rotateWallet(

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -34,6 +34,7 @@ contract DarkpoolTestBase is CalldataUtils {
     bytes constant INVALID_NULLIFIER_REVERT_STRING = "Nullifier already spent";
     bytes constant INVALID_ROOT_REVERT_STRING = "Merkle root not in history";
     bytes constant INVALID_SIGNATURE_REVERT_STRING = "Invalid signature";
+    bytes constant INVALID_PROTOCOL_FEE_REVERT_STRING = "Invalid protocol fee rate";
 
     function setUp() public {
         // Deploy a Permit2 instance for testing
@@ -47,7 +48,7 @@ contract DarkpoolTestBase is CalldataUtils {
         // Deploy the darkpool implementation contracts
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
         IVerifier verifier = new TestVerifier();
-        darkpool = new Darkpool(hasher, verifier, permit2);
+        darkpool = new Darkpool(TEST_PROTOCOL_FEE, hasher, verifier, permit2);
     }
 
     // ---------------------------

--- a/test/darkpool/SettleMatch.t.sol
+++ b/test/darkpool/SettleMatch.t.sol
@@ -116,4 +116,21 @@ contract SettleMatchTest is DarkpoolTestBase {
         vm.expectRevert(revertString);
         darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
     }
+
+    /// @notice Test settling a match in which the protocol fee rate is invalid
+    function test_settleMatch_invalidProtocolFeeRate() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory party0Payload,
+            PartyMatchPayload memory party1Payload,
+            ValidMatchSettleStatement memory statement,
+            MatchProofs memory proofs
+        ) = settleMatchCalldata(merkleRoot);
+        statement.protocolFeeRate = randomUint();
+
+        // Should fail
+        vm.expectRevert(INVALID_PROTOCOL_FEE_REVERT_STRING);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+    }
 }


### PR DESCRIPTION
### Purpose
This PR adds a protocol fee to the darkpool constructor and constrains the protocol fee in the `VALID MATCH SETTLE` statement passed to `processMatchSettle` with this value.

### Todo
- [ ] Match settlement proof linking

### Testing
- [x] Unit tests pass