### PR TITLE
librarires: verifier: Add match settle proof linking to batch opening

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -19,7 +19,12 @@ import {
 import { WalletOperations } from "./libraries/darkpool/WalletOperations.sol";
 import { TransferExecutor } from "./libraries/darkpool/ExternalTransfers.sol";
 import {
-    TransferAuthorization, isZero, PartyMatchPayload, MatchProofs, indicesEqual
+    TransferAuthorization,
+    isZero,
+    PartyMatchPayload,
+    MatchProofs,
+    MatchLinkingProofs,
+    indicesEqual
 } from "./libraries/darkpool/Types.sol";
 import { MerkleTreeLib } from "./libraries/merkle/MerkleTree.sol";
 import { NullifierLib } from "./libraries/darkpool/NullifierSet.sol";
@@ -148,7 +153,8 @@ contract Darkpool {
         PartyMatchPayload calldata party0MatchPayload,
         PartyMatchPayload calldata party1MatchPayload,
         ValidMatchSettleStatement calldata matchSettleStatement,
-        MatchProofs calldata proofs
+        MatchProofs calldata proofs,
+        MatchLinkingProofs calldata linkingProofs
     )
         public
     {
@@ -158,7 +164,7 @@ contract Darkpool {
         ValidReblindStatement calldata reblindStatement1 = party1MatchPayload.validReblindStatement;
 
         // 1. Verify the proofs
-        verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs);
+        verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs, linkingProofs);
 
         // 2. Check statement consistency between the proofs for the two parties
         // I.e. public inputs used in multiple proofs should take the same values

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { ValidCommitmentsStatement, ValidReblindStatement } from "./PublicInputs.sol";
-import { PlonkProof } from "../verifier/Types.sol";
+import { PlonkProof, LinkingProof } from "../verifier/Types.sol";
 
 /// @dev The type hash for the DepositWitness struct
 bytes32 constant DEPOSIT_WITNESS_TYPEHASH = keccak256("DepositWitness(uint256[4] pkRoot)");
@@ -106,6 +106,19 @@ struct MatchProofs {
     PlonkProof validReblind1;
     /// @dev The proof of `VALID MATCH SETTLE`
     PlonkProof validMatchSettle;
+}
+
+/// @title MatchLinkingProofs
+/// @notice Contains the proof linking arguments for a match
+struct MatchLinkingProofs {
+    /// @dev The proof of linked inputs between PARTY 0 VALID REBLIND <-> PARTY 0 VALID COMMITMENTS
+    LinkingProof validReblindCommitments0;
+    /// @dev The proof of linked inputs between PARTY 0 VALID COMMITMENTS <-> VALID MATCH SETTLE
+    LinkingProof validCommitmentsMatchSettle0;
+    /// @dev The proof of linked inputs between PARTY 1 VALID REBLIND <-> PARTY 1 VALID COMMITMENTS
+    LinkingProof validReblindCommitments1;
+    /// @dev The proof of linked inputs between PARTY 1 VALID COMMITMENTS <-> VALID MATCH SETTLE
+    LinkingProof validCommitmentsMatchSettle1;
 }
 
 /// @notice A set of indices into a settlement party's wallet for the receive balance

--- a/src/libraries/verifier/IVerifier.sol
+++ b/src/libraries/verifier/IVerifier.sol
@@ -7,7 +7,7 @@ import {
     ValidWalletUpdateStatement,
     ValidMatchSettleStatement
 } from "../darkpool/PublicInputs.sol";
-import { PartyMatchPayload, MatchProofs } from "../darkpool/Types.sol";
+import { PartyMatchPayload, MatchProofs, MatchLinkingProofs } from "../darkpool/Types.sol";
 
 interface IVerifier {
     /// @notice Verify a proof of `VALID WALLET CREATE`
@@ -44,7 +44,8 @@ interface IVerifier {
         PartyMatchPayload calldata party0MatchPayload,
         PartyMatchPayload calldata party1MatchPayload,
         ValidMatchSettleStatement calldata matchSettleStatement,
-        MatchProofs calldata proofs
+        MatchProofs calldata proofs,
+        MatchLinkingProofs calldata linkingProofs
     )
         external
         view

--- a/src/libraries/verifier/ProofLinking.sol
+++ b/src/libraries/verifier/ProofLinking.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 /// https://renegade-fi.notion.site/Proof-Linking-PlonK-00964f558b184e4c94b92247f4ebc5d8
 
 import { TranscriptLib, Transcript } from "./Transcript.sol";
-import { ProofLinkingArgument, OpeningElements, LinkingProof, ProofLinkingVK } from "./Types.sol";
+import { ProofLinkingInstance, OpeningElements, LinkingProof, ProofLinkingVK } from "./Types.sol";
 import { BN254Helpers } from "./BN254Helpers.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 
@@ -15,7 +15,7 @@ library ProofLinkingCore {
     /// @notice Create a set of opening elements for the proof linking relation
     /// @param arguments The proof linking arguments to create opening elements for
     /// @return The opening elements
-    function createOpeningElements(ProofLinkingArgument[] memory arguments)
+    function createOpeningElements(ProofLinkingInstance[] memory arguments)
         internal
         view
         returns (OpeningElements memory)

--- a/src/libraries/verifier/Types.sol
+++ b/src/libraries/verifier/Types.sol
@@ -85,7 +85,7 @@ struct Challenges {
 }
 
 /// @title An instance of a proof linking argument
-struct ProofLinkingArgument {
+struct ProofLinkingInstance {
     /// @dev The commitment to the first proof's first wire polynomial
     BN254.G1Point wire_comm0;
     /// @dev The commitment to the second proof's first wire polynomial

--- a/test/Verifier.t.sol
+++ b/test/Verifier.t.sol
@@ -11,7 +11,7 @@ import {
     VerificationKey,
     OpeningElements,
     emptyOpeningElements,
-    ProofLinkingArgument
+    ProofLinkingInstance
 } from "../src/libraries/verifier/Types.sol";
 import { ProofLinkingCore } from "../src/libraries/verifier/ProofLinking.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
@@ -426,7 +426,7 @@ contract VerifierTest is VerifierTestUtils {
             PlonkProof[] memory proofs,
             BN254.ScalarField[][] memory publicInputs,
             VerificationKey[] memory vks,
-            ProofLinkingArgument memory linkArg
+            ProofLinkingInstance memory linkArg
         ) = getSumProductProofsAndLinkingArgument(sharedInputs, sumPrivateInput, productPrivateInput);
 
         uint256 modType = randomUint(4);
@@ -446,7 +446,7 @@ contract VerifierTest is VerifierTestUtils {
         }
 
         // Assert that verification fails
-        ProofLinkingArgument[] memory linkArgs = new ProofLinkingArgument[](1);
+        ProofLinkingInstance[] memory linkArgs = new ProofLinkingInstance[](1);
         linkArgs[0] = linkArg;
         OpeningElements memory linkOpeningElements = ProofLinkingCore.createOpeningElements(linkArgs);
         bool res = VerifierCore.batchVerify(proofs, publicInputs, vks, linkOpeningElements);
@@ -563,11 +563,11 @@ contract VerifierTest is VerifierTestUtils {
             PlonkProof[] memory proofs,
             BN254.ScalarField[][] memory publicInputs,
             VerificationKey[] memory vks,
-            ProofLinkingArgument memory linkArg
+            ProofLinkingInstance memory linkArg
         ) = getSumProductProofsAndLinkingArgument(sharedInputs, sumPrivateInput, productPrivateInput);
 
         // Create extra opening elements for the proof linking relation
-        ProofLinkingArgument[] memory linkArgs = new ProofLinkingArgument[](1);
+        ProofLinkingInstance[] memory linkArgs = new ProofLinkingInstance[](1);
         linkArgs[0] = linkArg;
         OpeningElements memory linkingOpeningElements = ProofLinkingCore.createOpeningElements(linkArgs);
 

--- a/test/darkpool/SettleMatch.t.sol
+++ b/test/darkpool/SettleMatch.t.sol
@@ -5,7 +5,12 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 import { Test } from "forge-std/Test.sol";
 import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
 import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
-import { PartyMatchPayload, MatchProofs, TransferAuthorization } from "renegade/libraries/darkpool/Types.sol";
+import {
+    PartyMatchPayload,
+    MatchProofs,
+    MatchLinkingProofs,
+    TransferAuthorization
+} from "renegade/libraries/darkpool/Types.sol";
 import { ValidWalletUpdateStatement, ValidMatchSettleStatement } from "renegade/libraries/darkpool/PublicInputs.sol";
 
 contract SettleMatchTest is DarkpoolTestBase {
@@ -19,11 +24,12 @@ contract SettleMatchTest is DarkpoolTestBase {
             PartyMatchPayload memory party0Payload,
             PartyMatchPayload memory party1Payload,
             ValidMatchSettleStatement memory statement,
-            MatchProofs memory proofs
+            MatchProofs memory proofs,
+            MatchLinkingProofs memory linkingProofs
         ) = settleMatchCalldata(merkleRoot);
 
         // Process the match
-        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs, linkingProofs);
 
         // Check that the nullifiers are used
         BN254.ScalarField nullifier0 = party0Payload.validReblindStatement.originalSharesNullifier;
@@ -50,7 +56,8 @@ contract SettleMatchTest is DarkpoolTestBase {
             PartyMatchPayload memory party0Payload,
             PartyMatchPayload memory party1Payload,
             ValidMatchSettleStatement memory matchStatement,
-            MatchProofs memory matchProofs
+            MatchProofs memory matchProofs,
+            MatchLinkingProofs memory linkingProofs
         ) = settleMatchCalldata(merkleRoot);
 
         if (vm.randomBool()) {
@@ -63,7 +70,7 @@ contract SettleMatchTest is DarkpoolTestBase {
 
         // Should fail
         vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
-        darkpool.processMatchSettle(party0Payload, party1Payload, matchStatement, matchProofs);
+        darkpool.processMatchSettle(party0Payload, party1Payload, matchStatement, matchProofs, linkingProofs);
     }
 
     /// @notice Test settling a match in which one party is using an invalid Merkle root
@@ -74,7 +81,8 @@ contract SettleMatchTest is DarkpoolTestBase {
             PartyMatchPayload memory party0Payload,
             PartyMatchPayload memory party1Payload,
             ValidMatchSettleStatement memory statement,
-            MatchProofs memory proofs
+            MatchProofs memory proofs,
+            MatchLinkingProofs memory linkingProofs
         ) = settleMatchCalldata(merkleRoot);
 
         if (vm.randomBool()) {
@@ -87,7 +95,7 @@ contract SettleMatchTest is DarkpoolTestBase {
 
         // Should fail
         vm.expectRevert(INVALID_ROOT_REVERT_STRING);
-        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs, linkingProofs);
     }
 
     /// @notice Test settling a match in which one party's settlement indices are inconsistent
@@ -98,7 +106,8 @@ contract SettleMatchTest is DarkpoolTestBase {
             PartyMatchPayload memory party0Payload,
             PartyMatchPayload memory party1Payload,
             ValidMatchSettleStatement memory statement,
-            MatchProofs memory proofs
+            MatchProofs memory proofs,
+            MatchLinkingProofs memory linkingProofs
         ) = settleMatchCalldata(merkleRoot);
 
         bytes memory revertString;
@@ -114,7 +123,7 @@ contract SettleMatchTest is DarkpoolTestBase {
 
         // Should fail
         vm.expectRevert(revertString);
-        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs, linkingProofs);
     }
 
     /// @notice Test settling a match in which the protocol fee rate is invalid
@@ -125,12 +134,13 @@ contract SettleMatchTest is DarkpoolTestBase {
             PartyMatchPayload memory party0Payload,
             PartyMatchPayload memory party1Payload,
             ValidMatchSettleStatement memory statement,
-            MatchProofs memory proofs
+            MatchProofs memory proofs,
+            MatchLinkingProofs memory linkingProofs
         ) = settleMatchCalldata(merkleRoot);
         statement.protocolFeeRate = BN254.ScalarField.unwrap(randomScalar());
 
         // Should fail
         vm.expectRevert(INVALID_PROTOCOL_FEE_REVERT_STRING);
-        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs);
+        darkpool.processMatchSettle(party0Payload, party1Payload, statement, proofs, linkingProofs);
     }
 }

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -8,7 +8,7 @@ import {
     ValidMatchSettleStatement,
     StatementSerializer
 } from "../../src/libraries/darkpool/PublicInputs.sol";
-import { PartyMatchPayload, MatchProofs } from "../../src/libraries/darkpool/Types.sol";
+import { PartyMatchPayload, MatchProofs, MatchLinkingProofs } from "../../src/libraries/darkpool/Types.sol";
 import { VerificationKeys } from "../../src/libraries/darkpool/VerificationKeys.sol";
 import { IVerifier } from "../../src/libraries/verifier/IVerifier.sol";
 import { Verifier } from "../../src/Verifier.sol";
@@ -70,13 +70,14 @@ contract TestVerifier is IVerifier {
         PartyMatchPayload calldata party0MatchPayload,
         PartyMatchPayload calldata party1MatchPayload,
         ValidMatchSettleStatement calldata matchSettleStatement,
-        MatchProofs calldata proofs
+        MatchProofs calldata proofs,
+        MatchLinkingProofs calldata linkingProofs
     )
         external
         view
         returns (bool)
     {
-        verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs);
+        verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs, linkingProofs);
         return true;
     }
 }

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -7,7 +7,7 @@ import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
 import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
 import { IERC20 } from "oz-contracts/token/ERC20/IERC20.sol";
 import { TestUtils } from "./TestUtils.sol";
-import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
+import { PlonkProof, LinkingProof } from "renegade/libraries/verifier/Types.sol";
 import { IHasher } from "renegade/libraries/poseidon2/IHasher.sol";
 import {
     ExternalTransfer,
@@ -18,6 +18,7 @@ import {
     hashDepositWitness,
     publicKeyToUints,
     MatchProofs,
+    MatchLinkingProofs,
     PartyMatchPayload,
     OrderSettlementIndices
 } from "renegade/libraries/darkpool/Types.sol";
@@ -138,7 +139,8 @@ contract CalldataUtils is TestUtils {
             PartyMatchPayload memory party0Payload,
             PartyMatchPayload memory party1Payload,
             ValidMatchSettleStatement memory statement,
-            MatchProofs memory proofs
+            MatchProofs memory proofs,
+            MatchLinkingProofs memory linkingProofs
         )
     {
         party0Payload = generatePartyMatchPayload(merkleRoot);
@@ -159,6 +161,12 @@ contract CalldataUtils is TestUtils {
             validCommitments1: dummyPlonkProof(),
             validReblind1: dummyPlonkProof(),
             validMatchSettle: dummyPlonkProof()
+        });
+        linkingProofs = MatchLinkingProofs({
+            validReblindCommitments0: dummyLinkingProof(),
+            validCommitmentsMatchSettle0: dummyLinkingProof(),
+            validReblindCommitments1: dummyLinkingProof(),
+            validCommitmentsMatchSettle1: dummyLinkingProof()
         });
     }
 
@@ -335,5 +343,11 @@ contract CalldataUtils is TestUtils {
             sigma_evals: [dummyScalar, dummyScalar, dummyScalar, dummyScalar],
             z_bar: dummyScalar
         });
+    }
+
+    /// @notice Generates a dummy linking proof
+    function dummyLinkingProof() internal pure returns (LinkingProof memory proof) {
+        BN254.G1Point memory dummyPoint = BN254.P1();
+        proof = LinkingProof({ linking_quotient_poly_comm: dummyPoint, linking_poly_opening: dummyPoint });
     }
 }

--- a/test/utils/VerifierTestUtils.sol
+++ b/test/utils/VerifierTestUtils.sol
@@ -9,7 +9,7 @@ import {
     NUM_WIRE_TYPES,
     PlonkProof,
     ProofLinkingVK,
-    ProofLinkingArgument,
+    ProofLinkingInstance,
     LinkingProof
 } from "../../src/libraries/verifier/Types.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
@@ -284,7 +284,7 @@ contract VerifierTestUtils is TestUtils {
             PlonkProof[] memory proofs,
             BN254.ScalarField[][] memory publicInputs,
             VerificationKey[] memory vks,
-            ProofLinkingArgument memory linkingArgument
+            ProofLinkingInstance memory linkingArgument
         )
     {
         // Compute the expected sum and product, these are used as public inputs
@@ -329,7 +329,7 @@ contract VerifierTestUtils is TestUtils {
             abi.decode(vm.parseBytes(response), (PlonkProof, PlonkProof, LinkingProof));
 
         // Create a linking argument from the linking proof
-        ProofLinkingArgument memory linkArg = ProofLinkingArgument({
+        ProofLinkingInstance memory linkArg = ProofLinkingInstance({
             wire_comm0: sumProof.wire_comms[0],
             wire_comm1: productProof.wire_comms[0],
             proof: linkProof,


### PR DESCRIPTION
### Purpose
This PR implements the proof-linking needed to verify a match settlement, adding the proof linking arguments to all interfaces, and batching them into the opening verification.

### Todo
- [ ] Add proof-linking verification keys to the codegen script

### Testing
- Unit tests pass