### PR TITLE
Darkpool.sol, libraries: darkpool: Scaffold `processAtomicMatchSettle`

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -14,6 +14,7 @@ import {
     ValidCommitmentsStatement,
     ValidReblindStatement,
     ValidMatchSettleStatement,
+    ValidMatchSettleAtomicStatement,
     StatementSerializer
 } from "./libraries/darkpool/PublicInputs.sol";
 import { WalletOperations } from "./libraries/darkpool/WalletOperations.sol";
@@ -24,7 +25,9 @@ import {
     PartyMatchPayload,
     MatchProofs,
     MatchLinkingProofs,
-    indicesEqual
+    indicesEqual,
+    MatchAtomicProofs,
+    MatchAtomicLinkingProofs
 } from "./libraries/darkpool/Types.sol";
 import { MerkleTreeLib } from "./libraries/merkle/MerkleTree.sol";
 import { NullifierLib } from "./libraries/darkpool/NullifierSet.sol";
@@ -197,5 +200,20 @@ contract Darkpool {
             merkleTree,
             hasher
         );
+    }
+
+    /// @notice Process and atomic match settlement between two parties; one internal and one external
+    /// @dev An internal party is one with state committed into the darkpool, while
+    /// @dev an external party provides liquidity to the pool during the
+    /// @dev transaction in which this method is called
+    function processAtomicMatchSettle(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        public
+    {
+        require(false, "Not implemented");
     }
 }

--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -113,7 +113,7 @@ contract Verifier is IVerifier {
         vks[3] = reblindVk;
         vks[4] = settleVk;
 
-        // TODO: Add in proof linking
+        // Add proof linking instances to the opening
         ProofLinkingInstance[] memory instances = createMatchLinkingInstances(matchProofs, matchLinkingProofs);
         OpeningElements memory linkOpenings = ProofLinkingCore.createOpeningElements(instances);
 

--- a/src/libraries/darkpool/PublicInputs.sol
+++ b/src/libraries/darkpool/PublicInputs.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { ExternalTransfer, PublicRootKey, OrderSettlementIndices } from "./Types.sol";
+import { ExternalTransfer, PublicRootKey, OrderSettlementIndices, ExternalMatchResult, FeeTake } from "./Types.sol";
 
 // This file represents the public inputs (statements) for various proofs used by the darkpool
 
@@ -72,6 +72,26 @@ struct ValidMatchSettleStatement {
     uint256 protocolFeeRate;
 }
 
+/// @title ValidMatchSettleAtomicStatement
+/// @notice The statement type for the `VALID MATCH SETTLE ATOMIC` proof
+struct ValidMatchSettleAtomicStatement {
+    /// @dev The result of the match
+    ExternalMatchResult matchResult;
+    /// @dev The fees due by the external party
+    FeeTake externalPartyFees;
+    /// @dev The modified public shares of the internal party
+    BN254.ScalarField[] internalPartyModifiedShares;
+    /// @dev The order settlement indices of the internal party
+    OrderSettlementIndices internalPartySettlementIndices;
+    /// @dev The protocol fee rate used for the match
+    /// @dev This is a fixed point value encoded as a uint256,
+    /// @dev see `protocolFeeRate` in `ValidMatchSettleStatement`
+    uint256 protocolFeeRate;
+    /// @dev The address at which the relayer wishes to receive their fee due
+    /// @dev from the external party
+    address relayerFeeAddress;
+}
+
 // ------------------------
 // | Scalar Serialization |
 // ------------------------
@@ -83,6 +103,7 @@ library StatementSerializer {
     using StatementSerializer for ValidReblindStatement;
     using StatementSerializer for ValidCommitmentsStatement;
     using StatementSerializer for ValidMatchSettleStatement;
+    using StatementSerializer for ValidMatchSettleAtomicStatement;
     using StatementSerializer for ExternalTransfer;
     using StatementSerializer for PublicRootKey;
     using StatementSerializer for OrderSettlementIndices;
@@ -97,6 +118,8 @@ library StatementSerializer {
     uint256 constant VALID_COMMITMENTS_SCALAR_SIZE = 3;
     /// @notice The number of scalar field elements in a ValidMatchSettleStatement
     uint256 constant VALID_MATCH_SETTLE_SCALAR_SIZE = 147;
+    /// @notice The number of scalar field elements in a ValidMatchSettleAtomicStatement
+    uint256 constant VALID_MATCH_SETTLE_ATOMIC_SCALAR_SIZE = 82;
 
     // --- Valid Wallet Create --- //
 

--- a/src/libraries/darkpool/Types.sol
+++ b/src/libraries/darkpool/Types.sol
@@ -80,9 +80,46 @@ function hashDepositWitness(DepositWitness memory witness) pure returns (bytes32
     return keccak256(abi.encode(DEPOSIT_WITNESS_TYPEHASH, pkRootHash));
 }
 
+// -------------
+// | Fee Types |
+// -------------
+
+/// @title FeeTake
+/// @notice The fees due by a party in a match
+struct FeeTake {
+    /// @dev The fee due to the relayer
+    uint256 relayerFee;
+    /// @dev The fee due to the protocol
+    uint256 protocolFee;
+}
+
 // --------------------
 // | Settlement Types |
 // --------------------
+
+/// @title ExternalMatchResult
+/// @notice The result of a match between an internal and external party
+struct ExternalMatchResult {
+    /// @dev The quote mint of the match
+    address quoteMint;
+    /// @dev The base mint of the match
+    address baseMint;
+    /// @dev The amount of the match
+    uint256 quoteAmount;
+    /// @dev The amount of the match
+    uint256 baseAmount;
+    /// @dev The direction of the match
+    ExternalMatchDirection direction;
+}
+
+/// @title ExternalMatchDirection
+/// @notice The direction of a match between an internal and external party
+enum ExternalMatchDirection {
+    /// @dev The internal party buys the base and sells the quote
+    InternalPartyBuy,
+    /// @dev The internal party sells the base and buys the quote
+    InternalPartySell
+}
 
 /// @title PartyMatchPayload
 /// @notice Contains the statement types for a single party's validity proofs in a match
@@ -95,6 +132,8 @@ struct PartyMatchPayload {
 
 /// @title MatchProofs
 /// @notice Contains the proofs for a match between two parties in the darkpool
+/// @dev This contains the validity proofs for the two parties and a proof of
+/// @dev `VALID MATCH SETTLE` for settlement
 struct MatchProofs {
     /// @dev The first party's proof of `VALID COMMITMENTS`
     PlonkProof validCommitments0;
@@ -110,6 +149,9 @@ struct MatchProofs {
 
 /// @title MatchLinkingProofs
 /// @notice Contains the proof linking arguments for a match
+/// @dev This contains four proofs: two linking the internal party's `VALID REBLIND`
+/// @dev to their `VALID COMMITMENTS`, and two linking the internal party's
+/// @dev `VALID COMMITMENTS` to the proof of `VALID MATCH SETTLE`
 struct MatchLinkingProofs {
     /// @dev The proof of linked inputs between PARTY 0 VALID REBLIND <-> PARTY 0 VALID COMMITMENTS
     LinkingProof validReblindCommitments0;
@@ -119,6 +161,31 @@ struct MatchLinkingProofs {
     LinkingProof validReblindCommitments1;
     /// @dev The proof of linked inputs between PARTY 1 VALID COMMITMENTS <-> VALID MATCH SETTLE
     LinkingProof validCommitmentsMatchSettle1;
+}
+
+/// @title MatchAtomicProofs
+/// @notice Contains the proofs for a match between two parties in the darkpool
+/// @dev This contains the validity proofs for the internal party and a proof of
+/// @dev `VALID MATCH SETTLE ATOMIC` for settlement
+struct MatchAtomicProofs {
+    /// @dev The proof of `VALID COMMITMENTS` for the internal party
+    PlonkProof validCommitments;
+    /// @dev The proof of `VALID REBLIND` for the internal party
+    PlonkProof validReblind;
+    /// @dev The proof of `VALID MATCH SETTLE ATOMIC`
+    PlonkProof validMatchSettleAtomic;
+}
+
+/// @title MatchAtomicLinkingProofs
+/// @notice Contains the proof linking arguments for a match
+/// @dev This contains one proof that links the internal party's `VALID REBLIND`
+/// @dev to their `VALID COMMITMENTS`, and another that links the internal party's
+/// @dev `VALID COMMITMENTS` to the proof of `VALID MATCH SETTLE ATOMIC`
+struct MatchAtomicLinkingProofs {
+    /// @dev The proof of linked inputs between PARTY 0 VALID REBLIND <-> PARTY 0 VALID COMMITMENTS
+    LinkingProof validReblindCommitments;
+    /// @dev The proof of linked inputs between PARTY 0 VALID COMMITMENTS <-> VALID MATCH SETTLE ATOMIC
+    LinkingProof validCommitmentsMatchSettleAtomic;
 }
 
 /// @notice A set of indices into a settlement party's wallet for the receive balance


### PR DESCRIPTION
### Purpose
This PR adds the scaffolding for the `processAtomicMatchSettle` method on the darkpool. This method will receive a set of proofs and linking instances which prove validity for an internal party, and a bundle detailing the settlement information so that the external party's obligations to the trade may be enforced.

### Todo
- [ ] Implement contract method
- [ ] Write tests for `processAtomicMatchSettle`

### Testing
- [x] All existing unit tests pass