### PR TITLE
Darkpool.sol, Verifier.sol: Implement `pocessAtomicMatchSettle` and `verifyAtomicMatchBundle`

### DIFF
--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -14,9 +14,16 @@ import {
     ValidCommitmentsStatement,
     ValidReblindStatement,
     ValidMatchSettleStatement,
+    ValidMatchSettleAtomicStatement,
     StatementSerializer
 } from "./libraries/darkpool/PublicInputs.sol";
-import { PartyMatchPayload, MatchProofs, MatchLinkingProofs } from "./libraries/darkpool/Types.sol";
+import {
+    PartyMatchPayload,
+    MatchProofs,
+    MatchLinkingProofs,
+    MatchAtomicProofs,
+    MatchAtomicLinkingProofs
+} from "./libraries/darkpool/Types.sol";
 import { VerificationKeys } from "./libraries/darkpool/VerificationKeys.sol";
 import { IVerifier } from "./libraries/verifier/IVerifier.sol";
 import { VerifierCore } from "./libraries/verifier/VerifierCore.sol";
@@ -28,17 +35,22 @@ using StatementSerializer for ValidWalletUpdateStatement;
 using StatementSerializer for ValidCommitmentsStatement;
 using StatementSerializer for ValidReblindStatement;
 using StatementSerializer for ValidMatchSettleStatement;
+using StatementSerializer for ValidMatchSettleAtomicStatement;
 
 /// @title PlonK Verifier with the Jellyfish-style arithmetization
 /// @notice The methods on this contract are darkpool-specific
+
 contract Verifier is IVerifier {
     uint256 public constant NUM_MATCH_PROOFS = 5;
     uint256 public constant NUM_MATCH_LINKING_PROOFS = 4;
+    uint256 public constant NUM_ATOMIC_MATCH_PROOFS = 3;
+    uint256 public constant NUM_ATOMIC_MATCH_LINKING_PROOFS = 2;
 
     /// @notice Verify a proof of `VALID WALLET CREATE`
     /// @param statement The public inputs to the proof
     /// @param proof The proof to verify
     /// @return True if the proof is valid, false otherwise
+
     function verifyValidWalletCreate(
         ValidWalletCreateStatement memory statement,
         PlonkProof memory proof
@@ -121,6 +133,51 @@ contract Verifier is IVerifier {
         return VerifierCore.batchVerify(proofs, publicInputs, vks, linkOpenings);
     }
 
+    /// @notice Verify an atomic match bundle
+    /// @param internalPartyPayload The payload for the internal party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE ATOMIC`
+    /// @param matchProofs The proofs for the match, including a validity proof and a settlement proof
+    /// @param matchLinkingProofs The proof linking arguments for the match
+    /// @return True if the atomic match bundle is valid, false otherwise
+    function verifyAtomicMatchBundle(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata matchProofs,
+        MatchAtomicLinkingProofs calldata matchLinkingProofs
+    )
+        external
+        view
+        returns (bool)
+    {
+        // Load the verification keys
+        VerificationKey memory commitmentsVk = abi.decode(VerificationKeys.VALID_COMMITMENTS_VKEY, (VerificationKey));
+        VerificationKey memory reblindVk = abi.decode(VerificationKeys.VALID_REBLIND_VKEY, (VerificationKey));
+        VerificationKey memory settleVk = abi.decode(VerificationKeys.VALID_MATCH_SETTLE_ATOMIC_VKEY, (VerificationKey));
+
+        // Build the batch
+        PlonkProof[] memory proofs = new PlonkProof[](NUM_ATOMIC_MATCH_PROOFS);
+        BN254.ScalarField[][] memory publicInputs = new BN254.ScalarField[][](NUM_ATOMIC_MATCH_PROOFS);
+        VerificationKey[] memory vks = new VerificationKey[](NUM_ATOMIC_MATCH_PROOFS);
+        proofs[0] = matchProofs.validCommitments;
+        proofs[1] = matchProofs.validReblind;
+        proofs[2] = matchProofs.validMatchSettleAtomic;
+
+        publicInputs[0] = internalPartyPayload.validCommitmentsStatement.scalarSerialize();
+        publicInputs[1] = internalPartyPayload.validReblindStatement.scalarSerialize();
+        publicInputs[2] = matchSettleStatement.scalarSerialize();
+
+        vks[0] = commitmentsVk;
+        vks[1] = reblindVk;
+        vks[2] = settleVk;
+
+        // Add proof linking instances to the opening
+        ProofLinkingInstance[] memory instances = createAtomicMatchLinkingInstances(matchProofs, matchLinkingProofs);
+        OpeningElements memory linkOpenings = ProofLinkingCore.createOpeningElements(instances);
+
+        // Verify the batch
+        return VerifierCore.batchVerify(proofs, publicInputs, vks, linkOpenings);
+    }
+
     // --- Helpers --- //
 
     /// @notice Create a set of match linking instances
@@ -173,6 +230,44 @@ contract Verifier is IVerifier {
             wire_comm1: matchProofs.validMatchSettle.wire_comms[0],
             proof: matchLinkingProofs.validCommitmentsMatchSettle1,
             vk: commitmentsMatchSettleVk1
+        });
+    }
+
+    /// @notice Create a set of match linking instances for an atomic match bundle
+    /// @param matchProofs The proofs for the match, including a validity proof and a settlement proof
+    /// @param matchLinkingProofs The proof linking arguments for the match
+    /// @return instances A set of match linking instances
+    function createAtomicMatchLinkingInstances(
+        MatchAtomicProofs calldata matchProofs,
+        MatchAtomicLinkingProofs calldata matchLinkingProofs
+    )
+        internal
+        pure
+        returns (ProofLinkingInstance[] memory instances)
+    {
+        instances = new ProofLinkingInstance[](NUM_MATCH_LINKING_PROOFS);
+        ProofLinkingVK memory reblindCommitmentsVk =
+            abi.decode(VerificationKeys.VALID_REBLIND_COMMITMENTS_LINK_VKEY, (ProofLinkingVK));
+
+        // We link the internal party in an atomic match into the layout of the first party in an
+        // internal match, so we use that vkey directly here
+        ProofLinkingVK memory commitmentsMatchSettleVk =
+            abi.decode(VerificationKeys.VALID_COMMITMENTS_MATCH_SETTLE_LINK0_VKEY, (ProofLinkingVK));
+
+        // VALID REBLIND -> VALID COMMITMENTS
+        instances[0] = ProofLinkingInstance({
+            wire_comm0: matchProofs.validReblind.wire_comms[0],
+            wire_comm1: matchProofs.validCommitments.wire_comms[0],
+            proof: matchLinkingProofs.validReblindCommitments,
+            vk: reblindCommitmentsVk
+        });
+
+        // VALID COMMITMENTS -> VALID MATCH SETTLE ATOMIC
+        instances[1] = ProofLinkingInstance({
+            wire_comm0: matchProofs.validCommitments.wire_comms[0],
+            wire_comm1: matchProofs.validMatchSettleAtomic.wire_comms[0],
+            proof: matchLinkingProofs.validCommitmentsMatchSettleAtomic,
+            vk: commitmentsMatchSettleVk
         });
     }
 }

--- a/src/libraries/darkpool/Constants.sol
+++ b/src/libraries/darkpool/Constants.sol
@@ -12,4 +12,14 @@ library DarkpoolConstants {
     uint256 constant N_WALLET_SHARES = 70;
     /// @notice The depth of the Merkle tree
     uint256 constant MERKLE_DEPTH = 32;
+
+    /// @notice The address used for native ETH in trade settlement
+    address constant NATIVE_ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @notice Check whether an address is the native ETH address
+    /// @param addr The address to check
+    /// @return True if the address is the native ETH address, false otherwise
+    function isNativeEth(address addr) public pure returns (bool) {
+        return addr == NATIVE_ETH_ADDRESS;
+    }
 }

--- a/src/libraries/verifier/IVerifier.sol
+++ b/src/libraries/verifier/IVerifier.sol
@@ -5,9 +5,16 @@ import { PlonkProof } from "./Types.sol";
 import {
     ValidWalletCreateStatement,
     ValidWalletUpdateStatement,
-    ValidMatchSettleStatement
+    ValidMatchSettleStatement,
+    ValidMatchSettleAtomicStatement
 } from "../darkpool/PublicInputs.sol";
-import { PartyMatchPayload, MatchProofs, MatchLinkingProofs } from "../darkpool/Types.sol";
+import {
+    PartyMatchPayload,
+    MatchProofs,
+    MatchLinkingProofs,
+    MatchAtomicProofs,
+    MatchAtomicLinkingProofs
+} from "../darkpool/Types.sol";
 
 interface IVerifier {
     /// @notice Verify a proof of `VALID WALLET CREATE`
@@ -46,6 +53,22 @@ interface IVerifier {
         ValidMatchSettleStatement calldata matchSettleStatement,
         MatchProofs calldata proofs,
         MatchLinkingProofs calldata linkingProofs
+    )
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify an atomic match bundle
+    /// @param internalPartyPayload The payload for the internal party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE ATOMIC`
+    /// @param proofs The proofs for the match, including a validity proof and a settlement proof
+    /// @param linkingProofs The proof linking arguments for the match
+    /// @return True if the atomic match bundle is valid, false otherwise
+    function verifyAtomicMatchBundle(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
     )
         external
         view

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -6,17 +6,21 @@ import {
     ValidWalletCreateStatement,
     ValidWalletUpdateStatement,
     ValidMatchSettleStatement,
+    ValidMatchSettleAtomicStatement,
     StatementSerializer
 } from "../../src/libraries/darkpool/PublicInputs.sol";
-import { PartyMatchPayload, MatchProofs, MatchLinkingProofs } from "../../src/libraries/darkpool/Types.sol";
+import {
+    PartyMatchPayload,
+    MatchProofs,
+    MatchLinkingProofs,
+    MatchAtomicProofs,
+    MatchAtomicLinkingProofs
+} from "../../src/libraries/darkpool/Types.sol";
 import { VerificationKeys } from "../../src/libraries/darkpool/VerificationKeys.sol";
 import { IVerifier } from "../../src/libraries/verifier/IVerifier.sol";
 import { Verifier } from "../../src/Verifier.sol";
 import { VerifierCore } from "../../src/libraries/verifier/VerifierCore.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
-
-using StatementSerializer for ValidWalletCreateStatement;
-using StatementSerializer for ValidWalletUpdateStatement;
 
 /// @title Test Verifier Implementation
 /// @notice This is a test implementation of the `IVerifier` interface that always returns true
@@ -78,6 +82,26 @@ contract TestVerifier is IVerifier {
         returns (bool)
     {
         verifier.verifyMatchBundle(party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs, linkingProofs);
+        return true;
+    }
+
+    /// @notice Verify an atomic match bundle
+    /// @param internalPartyPayload The payload for the internal party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE ATOMIC`
+    /// @param proofs The proofs for the match, including a validity proof and a settlement proof
+    /// @param linkingProofs The proof linking arguments for the match
+    /// @return True always, regardless of the proof
+    function verifyAtomicMatchBundle(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        view
+        returns (bool)
+    {
+        verifier.verifyAtomicMatchBundle(internalPartyPayload, matchSettleStatement, proofs, linkingProofs);
         return true;
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds the bulk of the implementation for processing an atomic match settlement. This includes verifying the proofs, asserting consistency between statement values, and rotating the internal party's wallet.

### Todo
- [ ] External transfers for external party settlement
- [ ] Tests for atomic settlement

### Testing
- [x] All unit tests pass