### PR TITLE
test: darkpool: SettleAtomicMatch: Add basic atomic settlement tests

### DIFF
--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -35,6 +35,7 @@ contract DarkpoolTestBase is CalldataUtils {
     bytes constant INVALID_ROOT_REVERT_STRING = "Merkle root not in history";
     bytes constant INVALID_SIGNATURE_REVERT_STRING = "Invalid signature";
     bytes constant INVALID_PROTOCOL_FEE_REVERT_STRING = "Invalid protocol fee rate";
+    bytes constant INVALID_ETH_VALUE_REVERT_STRING = "Invalid ETH value, should be zero unless selling native ETH";
 
     function setUp() public {
         // Deploy a Permit2 instance for testing

--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { Test } from "forge-std/Test.sol";
+import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
+import {
+    PartyMatchPayload,
+    MatchAtomicProofs,
+    MatchAtomicLinkingProofs,
+    TransferAuthorization
+} from "renegade/libraries/darkpool/Types.sol";
+import {
+    ValidMatchSettleAtomicStatement, ValidWalletUpdateStatement
+} from "renegade/libraries/darkpool/PublicInputs.sol";
+import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
+
+contract SettleAtomicMatchTest is DarkpoolTestBase {
+    // --- Settle Atomic Match --- //
+
+    /// @notice Test settling an atomic match
+    function test_settleAtomicMatch_invalidValue() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldata(merkleRoot);
+
+        // Process the match
+        vm.expectRevert(INVALID_ETH_VALUE_REVERT_STRING);
+        darkpool.processAtomicMatchSettle{ value: 1 wei }(internalPartyPayload, statement, proofs, linkingProofs);
+    }
+
+    /// @notice Test settling an atomic match with a spent nullifier from the internal party
+    function test_settleAtomicMatch_spentNullifier() public {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        BN254.ScalarField nullifier = randomScalar();
+
+        // Update a wallet using the nullifier
+        (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
+            updateWalletCalldata(hasher);
+        statement.previousNullifier = nullifier;
+        statement.merkleRoot = merkleRoot;
+        TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
+        darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
+
+        // Setup calldata
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory matchStatement,
+            MatchAtomicProofs memory matchProofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldata(merkleRoot);
+
+        // Use the nullifier
+        internalPartyPayload.validReblindStatement.originalSharesNullifier = nullifier;
+
+        // Should fail
+        vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
+        darkpool.processAtomicMatchSettle(internalPartyPayload, matchStatement, matchProofs, linkingProofs);
+    }
+
+    /// @notice Test settling an atomic match with an invalid merkle root
+    function test_settleAtomicMatch_invalidMerkleRoot() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = randomScalar();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldata(merkleRoot);
+
+        // Should fail
+        vm.expectRevert(INVALID_ROOT_REVERT_STRING);
+        darkpool.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+    }
+
+    /// @notice Test settling an atomic match with inconsistent settlement indices for the internal party
+    function test_settleAtomicMatch_inconsistentIndices() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldata(merkleRoot);
+
+        internalPartyPayload.validCommitmentsStatement.indices = randomOrderSettlementIndices();
+
+        // Should fail
+        vm.expectRevert("Invalid internal party order settlement indices");
+        darkpool.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+    }
+
+    /// @notice Test settling an atomic match with an invalid protocol fee rate
+    function test_settleAtomicMatch_invalidProtocolFeeRate() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldata(merkleRoot);
+
+        statement.protocolFeeRate = BN254.ScalarField.unwrap(randomScalar());
+
+        // Should fail
+        vm.expectRevert(INVALID_PROTOCOL_FEE_REVERT_STRING);
+        darkpool.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+    }
+}

--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -18,7 +18,7 @@ import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
 contract SettleAtomicMatchTest is DarkpoolTestBase {
     // --- Settle Atomic Match --- //
 
-    /// @notice Test settling an atomic match
+    /// @notice Test settling an atomic match with an invalid ETH value
     function test_settleAtomicMatch_invalidValue() public {
         // Setup calldata
         BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -51,6 +51,12 @@ contract TestUtils is Test {
         return vm.randomUint(low, high - 1);
     }
 
+    /// @dev Generate a random `Amount` in the renegade system
+    /// @dev Amounts are constrained to be in the range [0, 2 ** 100)
+    function randomAmount() internal returns (uint256) {
+        return randomUint(2 ** 100);
+    }
+
     /// @dev Generate a random set of wallet shares
     function randomWalletShares() internal returns (BN254.ScalarField[] memory) {
         BN254.ScalarField[] memory shares = new BN254.ScalarField[](DarkpoolConstants.N_WALLET_SHARES);


### PR DESCRIPTION
### Purpose
This PR adds a basic test suite for atomic match settlement which test the majority of invalid cases.

### Todo
- [ ] External transfers in atomic settlement
- [ ] Full test suite after external transfers are implemented

### Testing
- [x] Unit tests pass