### PR TITLE
Darkpool.sol: Execute transfers for external match

### DIFF
--- a/src/libraries/darkpool/ExternalTransfers.sol
+++ b/src/libraries/darkpool/ExternalTransfers.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.20;
 
 import {
+    TypesLib,
     ExternalTransfer,
     TransferType,
     TransferAuthorization,
     PublicRootKey,
     publicKeyToUints,
     DepositWitness,
-    hashDepositWitness,
     DEPOSIT_WITNESS_TYPE_STRING
 } from "../darkpool/Types.sol";
 import { WalletOperations } from "../darkpool/WalletOperations.sol";
@@ -20,6 +20,32 @@ import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 // @notice This library implements the logic for executing external transfers
 // @notice External transfers are either deposits or withdrawals into/from the darkpool
 library TransferExecutor {
+    using TypesLib for DepositWitness;
+
+    // --- Types --- //
+
+    /// @notice A simple ERC20 transfer
+    struct SimpleTransfer {
+        /// @dev The address to withdraw to or deposit from
+        address account;
+        /// @dev The ERC20 token to transfer
+        address mint;
+        /// @dev The amount of tokens to transfer
+        uint256 amount;
+        /// @dev The type of transfer
+        SimpleTransferType transferType;
+    }
+
+    /// @notice The type of a simple ERC20 transfer
+    enum SimpleTransferType {
+        /// @dev A withdrawal
+        Withdrawal,
+        /// @dev A deposit
+        Deposit
+    }
+
+    // --- Interface --- //
+
     /// @notice Executes an external transfer (deposit or withdrawal) for the darkpool
     /// @param transfer The external transfer details including account, mint, amount and type
     /// @param oldPkRoot The public root key of the sender's Renegade wallet
@@ -38,6 +64,24 @@ library TransferExecutor {
             executeDeposit(oldPkRoot, transfer, authorization, permit2);
         } else {
             executeWithdrawal(oldPkRoot, transfer, authorization);
+        }
+    }
+
+    /// @notice Execute a batch of simple ERC20 transfers
+    function executeTransferBatch(SimpleTransfer[] memory transfers) internal {
+        for (uint256 i = 0; i < transfers.length; i++) {
+            // Do nothing if the transfer amount i zero
+            if (transfers[i].amount == 0) {
+                continue;
+            }
+
+            // Otherwise, execute the transfer
+            SimpleTransferType transferType = transfers[i].transferType;
+            if (transferType == SimpleTransferType.Withdrawal) {
+                executeSimpleWithdrawal(transfers[i]);
+            } else {
+                executeSimpleDeposit(transfers[i]);
+            }
         }
     }
 
@@ -69,7 +113,7 @@ library TransferExecutor {
         ISignatureTransfer.SignatureTransferDetails memory signatureTransferDetails =
             ISignatureTransfer.SignatureTransferDetails({ to: address(this), requestedAmount: transfer.amount });
         DepositWitness memory depositWitness = DepositWitness({ pkRoot: publicKeyToUints(oldPkRoot) });
-        bytes32 depositWitnessHash = hashDepositWitness(depositWitness);
+        bytes32 depositWitnessHash = depositWitness.hashWitness();
 
         address owner = transfer.account;
         permit2.permitWitnessTransferFrom(
@@ -80,6 +124,15 @@ library TransferExecutor {
             DEPOSIT_WITNESS_TYPE_STRING,
             authorization.permit2Signature
         );
+    }
+
+    /// @notice Execute a simple ERC20 deposit
+    /// @dev It is assumed that the address from which we deposit has approved the darkpool to spend the tokens
+    function executeSimpleDeposit(SimpleTransfer memory transfer) internal {
+        // TODO: Handle native token deposits
+        IERC20 token = IERC20(transfer.mint);
+        address self = address(this);
+        token.transferFrom(transfer.account, self, transfer.amount);
     }
 
     // --- Withdrawal --- //
@@ -101,6 +154,13 @@ library TransferExecutor {
         require(sigValid, "Invalid withdrawal signature");
 
         // 2. Execute the withdrawal as a direct ERC20 transfer
+        IERC20 token = IERC20(transfer.mint);
+        token.transfer(transfer.account, transfer.amount);
+    }
+
+    /// @notice Execute a simple ERC20 withdrawal
+    function executeSimpleWithdrawal(SimpleTransfer memory transfer) internal {
+        // TODO: Handle native token withdrawals
         IERC20 token = IERC20(transfer.mint);
         token.transfer(transfer.account, transfer.amount);
     }

--- a/test/BN254Helpers.t.sol
+++ b/test/BN254Helpers.t.sol
@@ -13,7 +13,7 @@ contract BN254HelpersTest is TestUtils {
     }
 
     /// @notice Test the root of unity function
-    function testRootOfUnity() public {
+    function testRootOfUnity() public pure {
         RootOfUnityTest[] memory testCases = new RootOfUnityTest[](6);
 
         // Test case for n = 2^1

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -10,12 +10,12 @@ import { TestUtils } from "./TestUtils.sol";
 import { PlonkProof, LinkingProof } from "renegade/libraries/verifier/Types.sol";
 import { IHasher } from "renegade/libraries/poseidon2/IHasher.sol";
 import {
+    TypesLib,
     ExternalTransfer,
     PublicRootKey,
     TransferType,
     TransferAuthorization,
     DepositWitness,
-    hashDepositWitness,
     publicKeyToUints,
     MatchProofs,
     MatchLinkingProofs,
@@ -46,6 +46,8 @@ bytes32 constant PERMIT_TRANSFER_FROM_TYPEHASH = keccak256(
 /// @title Calldata Utils
 /// @notice Utilities for generating darkpool calldata
 contract CalldataUtils is TestUtils {
+    using TypesLib for DepositWitness;
+
     /// @notice The floating point precision used in the fixed point representation
     uint256 public constant FIXED_POINT_PRECISION = 2 ** 63;
     /// @notice The protocol fee rate used for testing
@@ -350,7 +352,7 @@ contract CalldataUtils is TestUtils {
         ISignatureTransfer.PermitTransferFrom memory permit =
             ISignatureTransfer.PermitTransferFrom({ permitted: tokenPermissions, nonce: nonce, deadline: deadline });
         DepositWitness memory depositWitness = DepositWitness({ pkRoot: publicKeyToUints(oldPkRoot) });
-        bytes32 depositWitnessHash = hashDepositWitness(depositWitness);
+        bytes32 depositWitnessHash = depositWitness.hashWitness();
 
         bytes memory sig = getPermitWitnessTransferSignature(
             permit,


### PR DESCRIPTION
### Purpose
This PR adds the basic ERC20 transfer logic for the `processAtomicMatch` method.

### Todo
- Native ERC20 transfers
- External match with non-sender receiver
- Full test suite for `processAtomicMatch`

### Testing
- [x] All unit tests pass