### PR TITLE
test: darkpool: SettleAtomicMatch: Test basic atomic match settlement

### DIFF
--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -28,8 +28,10 @@ contract DarkpoolTestBase is CalldataUtils {
     IHasher public hasher;
     NullifierLib.NullifierSet private testNullifierSet;
     IPermit2 public permit2;
-    ERC20Mock public token1;
-    ERC20Mock public token2;
+    ERC20Mock public quoteToken;
+    ERC20Mock public baseToken;
+
+    address public protocolFeeAddr;
 
     bytes constant INVALID_NULLIFIER_REVERT_STRING = "Nullifier already spent";
     bytes constant INVALID_ROOT_REVERT_STRING = "Merkle root not in history";
@@ -43,13 +45,14 @@ contract DarkpoolTestBase is CalldataUtils {
         permit2 = IPermit2(permit2Deployer.deployPermit2());
 
         // Deploy mock tokens for testing
-        token1 = new ERC20Mock();
-        token2 = new ERC20Mock();
+        quoteToken = new ERC20Mock();
+        baseToken = new ERC20Mock();
 
         // Deploy the darkpool implementation contracts
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
         IVerifier verifier = new TestVerifier();
-        darkpool = new Darkpool(TEST_PROTOCOL_FEE, hasher, verifier, permit2);
+        protocolFeeAddr = vm.randomAddress();
+        darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, hasher, verifier, permit2);
     }
 
     // ---------------------------

--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -1,22 +1,199 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
+import { Vm } from "forge-std/Vm.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
 import { Test } from "forge-std/Test.sol";
 import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
 import {
+    TypesLib,
     PartyMatchPayload,
     MatchAtomicProofs,
     MatchAtomicLinkingProofs,
-    TransferAuthorization
+    TransferAuthorization,
+    ExternalMatchDirection,
+    ExternalMatchResult,
+    FeeTake
 } from "renegade/libraries/darkpool/Types.sol";
 import {
     ValidMatchSettleAtomicStatement, ValidWalletUpdateStatement
 } from "renegade/libraries/darkpool/PublicInputs.sol";
 import { PlonkProof } from "renegade/libraries/verifier/Types.sol";
+import { console2 } from "forge-std/console2.sol";
 
 contract SettleAtomicMatchTest is DarkpoolTestBase {
-    // --- Settle Atomic Match --- //
+    using TypesLib for FeeTake;
+
+    // --- Valid Match Tests --- //
+
+    /// @notice Test settling an atomic match with the external party buy side
+    /// @dev This is the only test in which we test fee receipt
+    function test_settleAtomicMatch_externalPartyBuySide() public {
+        Vm.Wallet memory externalParty = randomEthereumWallet();
+        address relayerFeeAddr = vm.randomAddress();
+        uint256 quoteAmount = 1_000_000;
+        uint256 baseAmount = 5_000_000;
+
+        // Setup tokens
+        quoteToken.mint(externalParty.addr, quoteAmount);
+        baseToken.mint(address(darkpool), baseAmount);
+
+        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
+        uint256 userInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
+        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
+        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
+        uint256 relayerInitialQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
+        uint256 relayerInitialBaseBalance = baseToken.balanceOf(relayerFeeAddr);
+        uint256 protocolInitialQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
+        uint256 protocolInitialBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+
+        // Setup the match
+        ExternalMatchResult memory matchResult = ExternalMatchResult({
+            quoteMint: address(quoteToken),
+            baseMint: address(baseToken),
+            quoteAmount: quoteAmount,
+            baseAmount: baseAmount,
+            direction: ExternalMatchDirection.InternalPartySell
+        });
+
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldataWithMatchResult(merkleRoot, matchResult);
+        statement.relayerFeeAddress = relayerFeeAddr;
+
+        // Process the match
+        vm.startBroadcast(externalParty.addr);
+        quoteToken.approve(address(darkpool), quoteAmount);
+        darkpool.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+        vm.stopBroadcast();
+
+        // Check the token flows
+        FeeTake memory fees = statement.externalPartyFees;
+        uint256 totalFee = fees.total();
+        uint256 expectedBaseAmt = baseAmount - totalFee;
+
+        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
+        uint256 userFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
+        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
+        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
+        uint256 relayerFinalQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
+        uint256 relayerFinalBaseBalance = baseToken.balanceOf(relayerFeeAddr);
+        uint256 protocolFinalQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
+        uint256 protocolFinalBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+
+        assertEq(userFinalQuoteBalance, userInitialQuoteBalance - quoteAmount);
+        assertEq(userFinalBaseBalance, userInitialBaseBalance + expectedBaseAmt);
+        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance + quoteAmount);
+        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance - baseAmount);
+        assertEq(relayerFinalQuoteBalance, relayerInitialQuoteBalance);
+        assertEq(relayerFinalBaseBalance, relayerInitialBaseBalance + fees.relayerFee);
+        assertEq(protocolFinalQuoteBalance, protocolInitialQuoteBalance);
+        assertEq(protocolFinalBaseBalance, protocolInitialBaseBalance + fees.protocolFee);
+    }
+
+    /// @notice Test settling an atomic match with the external party sell side
+    /// @dev This is the only test in which we test fee receipt
+    function test_settleAtomicMatch_externalPartySellSide() public {
+        Vm.Wallet memory externalParty = randomEthereumWallet();
+        address relayerFeeAddr = vm.randomAddress();
+        uint256 quoteAmount = 100_000;
+        uint256 baseAmount = 500_000;
+
+        // Setup tokens
+        quoteToken.mint(address(darkpool), quoteAmount);
+        baseToken.mint(externalParty.addr, baseAmount);
+
+        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
+        uint256 userInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
+        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
+        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
+        uint256 relayerInitialQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
+        uint256 relayerInitialBaseBalance = baseToken.balanceOf(relayerFeeAddr);
+        uint256 protocolInitialQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
+        uint256 protocolInitialBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+
+        // Setup the match
+        ExternalMatchResult memory matchResult = ExternalMatchResult({
+            quoteMint: address(quoteToken),
+            baseMint: address(baseToken),
+            quoteAmount: quoteAmount,
+            baseAmount: baseAmount,
+            direction: ExternalMatchDirection.InternalPartyBuy
+        });
+
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldataWithMatchResult(merkleRoot, matchResult);
+        statement.relayerFeeAddress = relayerFeeAddr;
+
+        // Process the match
+        vm.startBroadcast(externalParty.addr);
+        baseToken.approve(address(darkpool), baseAmount);
+        darkpool.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+        vm.stopBroadcast();
+
+        // Check the token flows
+        FeeTake memory fees = statement.externalPartyFees;
+        uint256 totalFee = fees.total();
+        uint256 expectedQuoteAmt = quoteAmount - totalFee;
+
+        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
+        uint256 userFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
+        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
+        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
+        uint256 relayerFinalQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
+        uint256 relayerFinalBaseBalance = baseToken.balanceOf(relayerFeeAddr);
+        uint256 protocolFinalQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
+        uint256 protocolFinalBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+
+        assertEq(userFinalQuoteBalance, userInitialQuoteBalance + expectedQuoteAmt);
+        assertEq(userFinalBaseBalance, userInitialBaseBalance - baseAmount);
+        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance - quoteAmount);
+        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance + baseAmount);
+        assertEq(relayerFinalQuoteBalance, relayerInitialQuoteBalance + fees.relayerFee);
+        assertEq(relayerFinalBaseBalance, relayerInitialBaseBalance);
+        assertEq(protocolFinalQuoteBalance, protocolInitialQuoteBalance + fees.protocolFee);
+        assertEq(protocolFinalBaseBalance, protocolInitialBaseBalance);
+    }
+
+    // --- Invalid Match Tests --- //
+
+    /// @notice Test settling an atomic match wherein the fees exceed the receive amount
+    function test_settleAtomicMatch_feesExceedReceiveAmount() public {
+        // Setup match
+        ExternalMatchResult memory matchResult = ExternalMatchResult({
+            quoteMint: address(quoteToken),
+            baseMint: address(baseToken),
+            quoteAmount: 100,
+            baseAmount: 100,
+            direction: ExternalMatchDirection.InternalPartyBuy
+        });
+
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldataWithMatchResult(merkleRoot, matchResult);
+        statement.externalPartyFees.relayerFee = 101; // More than receive amount
+
+        // Process the match
+        vm.expectRevert();
+        darkpool.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+    }
 
     /// @notice Test settling an atomic match with an invalid ETH value
     function test_settleAtomicMatch_invalidValue() public {

--- a/test/darkpool/UpdateWallet.t.sol
+++ b/test/darkpool/UpdateWallet.t.sol
@@ -93,15 +93,15 @@ contract UpdateWalletTest is DarkpoolTestBase {
         // Generate keys for the on-chain wallet and the user wallet
         Vm.Wallet memory userWallet = randomEthereumWallet();
         Vm.Wallet memory rootKeyWallet = randomEthereumWallet();
-        token1.mint(userWallet.addr, depositAmount);
+        quoteToken.mint(userWallet.addr, depositAmount);
 
-        uint256 darkpoolBalanceBefore = token1.balanceOf(address(darkpool));
-        uint256 userBalanceBefore = token1.balanceOf(userWallet.addr);
+        uint256 darkpoolBalanceBefore = quoteToken.balanceOf(address(darkpool));
+        uint256 userBalanceBefore = quoteToken.balanceOf(userWallet.addr);
 
         // Setup calldata
         ExternalTransfer memory transfer = ExternalTransfer({
             account: userWallet.addr,
-            mint: address(token1),
+            mint: address(quoteToken),
             amount: depositAmount,
             transferType: TransferType.Deposit
         });
@@ -118,8 +118,8 @@ contract UpdateWalletTest is DarkpoolTestBase {
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
 
         // Check that the user token balance has decreased
-        uint256 darkpoolBalanceAfter = token1.balanceOf(address(darkpool));
-        uint256 userBalanceAfter = token1.balanceOf(userWallet.addr);
+        uint256 darkpoolBalanceAfter = quoteToken.balanceOf(address(darkpool));
+        uint256 userBalanceAfter = quoteToken.balanceOf(userWallet.addr);
         assertEq(darkpoolBalanceAfter, darkpoolBalanceBefore + depositAmount);
         assertEq(userBalanceAfter, userBalanceBefore - depositAmount);
     }
@@ -131,14 +131,14 @@ contract UpdateWalletTest is DarkpoolTestBase {
         // Generate keys for the on-chain wallet and the Renegade wallet
         Vm.Wallet memory userWallet = randomEthereumWallet();
         Vm.Wallet memory rootKeyWallet = randomEthereumWallet();
-        token1.mint(address(darkpool), withdrawalAmount);
-        uint256 darkpoolBalanceBefore = token1.balanceOf(address(darkpool));
-        uint256 userBalanceBefore = token1.balanceOf(userWallet.addr);
+        quoteToken.mint(address(darkpool), withdrawalAmount);
+        uint256 darkpoolBalanceBefore = quoteToken.balanceOf(address(darkpool));
+        uint256 userBalanceBefore = quoteToken.balanceOf(userWallet.addr);
 
         // Setup calldata
         ExternalTransfer memory transfer = ExternalTransfer({
             account: userWallet.addr,
-            mint: address(token1),
+            mint: address(quoteToken),
             amount: withdrawalAmount,
             transferType: TransferType.Withdrawal
         });
@@ -153,8 +153,8 @@ contract UpdateWalletTest is DarkpoolTestBase {
         darkpool.updateWallet(newSharesCommitmentSig, transferAuthorization, statement, proof);
 
         // Check that the user token balance has increased
-        uint256 darkpoolBalanceAfter = token1.balanceOf(address(darkpool));
-        uint256 userBalanceAfter = token1.balanceOf(userWallet.addr);
+        uint256 darkpoolBalanceAfter = quoteToken.balanceOf(address(darkpool));
+        uint256 userBalanceAfter = quoteToken.balanceOf(userWallet.addr);
         assertEq(darkpoolBalanceAfter, darkpoolBalanceBefore - withdrawalAmount);
         assertEq(userBalanceAfter, userBalanceBefore + withdrawalAmount);
     }


### PR DESCRIPTION
### Purpose
This PR adds a sub-suite of tests which verify correct execution of basic atomic settlement, both on sell side and buy side. The tests verify the base and quote token balances of the darkpool, the external party, the relayer fee address, and the protocol fee address.

I also added the protocol fee address to the darkpool constructor.

### Todo
- Native asset support
- Per-asset fee overrides

### Testing
- [x] Unit tests pass