### PR TITLE
Darkpool.sol, libraries: darkpool: Implement `settleOfflineFee`

### DIFF
--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -15,6 +15,7 @@ import {
     ValidReblindStatement,
     ValidMatchSettleStatement,
     ValidMatchSettleAtomicStatement,
+    ValidOfflineFeeSettlementStatement,
     StatementSerializer
 } from "./libraries/darkpool/PublicInputs.sol";
 import {
@@ -36,6 +37,7 @@ using StatementSerializer for ValidCommitmentsStatement;
 using StatementSerializer for ValidReblindStatement;
 using StatementSerializer for ValidMatchSettleStatement;
 using StatementSerializer for ValidMatchSettleAtomicStatement;
+using StatementSerializer for ValidOfflineFeeSettlementStatement;
 
 /// @title PlonK Verifier with the Jellyfish-style arithmetization
 /// @notice The methods on this contract are darkpool-specific
@@ -176,6 +178,23 @@ contract Verifier is IVerifier {
 
         // Verify the batch
         return VerifierCore.batchVerify(proofs, publicInputs, vks, linkOpenings);
+    }
+
+    /// @notice Verify a proof of `VALID OFFLINE FEE SETTLEMENT`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidOfflineFeeSettlement(
+        ValidOfflineFeeSettlementStatement calldata statement,
+        PlonkProof calldata proof
+    )
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = abi.decode(VerificationKeys.VALID_OFFLINE_FEE_SETTLEMENT_VKEY, (VerificationKey));
+        BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
+        return VerifierCore.verify(proof, publicInputs, vk);
     }
 
     // --- Helpers --- //

--- a/src/libraries/darkpool/Constants.sol
+++ b/src/libraries/darkpool/Constants.sol
@@ -12,6 +12,8 @@ library DarkpoolConstants {
     uint256 constant N_WALLET_SHARES = 70;
     /// @notice The depth of the Merkle tree
     uint256 constant MERKLE_DEPTH = 32;
+    /// @notice The maximum number of leaves in the merkle tree
+    uint256 constant MAX_MERKLE_LEAVES = 2 ** MERKLE_DEPTH;
 
     /// @notice The address used for native tokens in trade settlement
     /// @dev This is currently just ETH, but intentionally written abstractly

--- a/src/libraries/interfaces/IVerifier.sol
+++ b/src/libraries/interfaces/IVerifier.sol
@@ -6,7 +6,8 @@ import {
     ValidWalletCreateStatement,
     ValidWalletUpdateStatement,
     ValidMatchSettleStatement,
-    ValidMatchSettleAtomicStatement
+    ValidMatchSettleAtomicStatement,
+    ValidOfflineFeeSettlementStatement
 } from "renegade/libraries/darkpool/PublicInputs.sol";
 import {
     PartyMatchPayload,
@@ -69,6 +70,18 @@ interface IVerifier {
         ValidMatchSettleAtomicStatement calldata matchSettleStatement,
         MatchAtomicProofs calldata proofs,
         MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `VALID OFFLINE FEE SETTLEMENT`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidOfflineFeeSettlement(
+        ValidOfflineFeeSettlementStatement calldata statement,
+        PlonkProof calldata proof
     )
         external
         view

--- a/src/libraries/merkle/MerkleTree.sol
+++ b/src/libraries/merkle/MerkleTree.sol
@@ -65,6 +65,8 @@ library MerkleTreeLib {
     function insertLeaf(MerkleTree storage tree, BN254.ScalarField leaf, IHasher hasher) internal {
         // Compute the hash of the leaf into the tree
         uint256 idx = tree.nextIndex;
+        require(idx < DarkpoolConstants.MAX_MERKLE_LEAVES, "Merkle tree is full");
+
         uint256 leafUint = BN254.ScalarField.unwrap(leaf);
         uint256[] memory sisterLeaves = new uint256[](tree.siblingPath.length);
         for (uint256 i = 0; i < tree.siblingPath.length; i++) {

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -12,7 +12,11 @@ import { CalldataUtils } from "../utils/CalldataUtils.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { Vm } from "forge-std/Vm.sol";
 import {
-    ExternalTransfer, TransferType, TransferAuthorization, PublicRootKey
+    ExternalTransfer,
+    TransferType,
+    TransferAuthorization,
+    PublicRootKey,
+    EncryptionKey
 } from "renegade/libraries/darkpool/Types.sol";
 import { TestVerifier } from "../test-contracts/TestVerifier.sol";
 import { Darkpool } from "renegade/Darkpool.sol";
@@ -59,7 +63,8 @@ contract DarkpoolTestBase is CalldataUtils {
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
         IVerifier verifier = new TestVerifier();
         protocolFeeAddr = vm.randomAddress();
-        darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, weth, hasher, verifier, permit2);
+        EncryptionKey memory protocolFeeKey = randomEncryptionKey();
+        darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, verifier, permit2);
     }
 
     // ---------------------------

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -7,6 +7,7 @@ import {
     ValidWalletUpdateStatement,
     ValidMatchSettleStatement,
     ValidMatchSettleAtomicStatement,
+    ValidOfflineFeeSettlementStatement,
     StatementSerializer
 } from "renegade/libraries/darkpool/PublicInputs.sol";
 import {
@@ -102,6 +103,22 @@ contract TestVerifier is IVerifier {
         returns (bool)
     {
         verifier.verifyAtomicMatchBundle(internalPartyPayload, matchSettleStatement, proofs, linkingProofs);
+        return true;
+    }
+
+    /// @notice Verify a proof of `VALID OFFLINE FEE SETTLEMENT`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True always, regardless of the proof
+    function verifyValidOfflineFeeSettlement(
+        ValidOfflineFeeSettlementStatement calldata statement,
+        PlonkProof calldata proof
+    )
+        external
+        view
+        returns (bool)
+    {
+        verifier.verifyValidOfflineFeeSettlement(statement, proof);
         return true;
     }
 }

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -25,7 +25,10 @@ import {
     ExternalMatchResult,
     ExternalMatchDirection,
     FeeTake,
-    OrderSettlementIndices
+    OrderSettlementIndices,
+    EncryptionKey,
+    ElGamalCiphertext,
+    BabyJubJubPoint
 } from "renegade/libraries/darkpool/Types.sol";
 import { DarkpoolConstants } from "renegade/libraries/darkpool/Constants.sol";
 import { uintToScalarWords, WalletOperations } from "renegade/libraries/darkpool/WalletOperations.sol";
@@ -441,6 +444,15 @@ contract CalldataUtils is TestUtils {
         (BN254.ScalarField xLow, BN254.ScalarField xHigh) = uintToScalarWords(wallet.publicKeyX);
         (BN254.ScalarField yLow, BN254.ScalarField yHigh) = uintToScalarWords(wallet.publicKeyY);
         rootKey = PublicRootKey({ x: [xLow, xHigh], y: [yLow, yHigh] });
+    }
+
+    /// --- Encryption --- ///
+
+    /// @notice Generate a random encryption key
+    /// @dev For our purposes, this key does not need to be on the curve,
+    /// @dev no curve arithmetic is performed on it
+    function randomEncryptionKey() internal returns (EncryptionKey memory key) {
+        key = EncryptionKey({ point: BabyJubJubPoint({ x: randomScalar(), y: randomScalar() }) });
     }
 
     /// --- Plonk Proofs --- ///


### PR DESCRIPTION
### Purpose
This PR implements the `settleOfflineFee` method on the darkpool. This method settles a fee by generating a note and inserting the note's commitment into the Merkle tree. The note may be redeemed later by the recipient via a proof of decryption. 

### Todo
- Tests for offline fee settlement

### Testing
- [x] Unit tests pass