### PR TITLE
Darkpool.sol: Implement `redeemFee`

### DIFF
--- a/src/Verifier.sol
+++ b/src/Verifier.sol
@@ -16,6 +16,7 @@ import {
     ValidMatchSettleStatement,
     ValidMatchSettleAtomicStatement,
     ValidOfflineFeeSettlementStatement,
+    ValidFeeRedemptionStatement,
     StatementSerializer
 } from "./libraries/darkpool/PublicInputs.sol";
 import {
@@ -38,10 +39,10 @@ using StatementSerializer for ValidReblindStatement;
 using StatementSerializer for ValidMatchSettleStatement;
 using StatementSerializer for ValidMatchSettleAtomicStatement;
 using StatementSerializer for ValidOfflineFeeSettlementStatement;
+using StatementSerializer for ValidFeeRedemptionStatement;
 
 /// @title PlonK Verifier with the Jellyfish-style arithmetization
 /// @notice The methods on this contract are darkpool-specific
-
 contract Verifier is IVerifier {
     uint256 public constant NUM_MATCH_PROOFS = 5;
     uint256 public constant NUM_MATCH_LINKING_PROOFS = 4;
@@ -193,6 +194,23 @@ contract Verifier is IVerifier {
         returns (bool)
     {
         VerificationKey memory vk = abi.decode(VerificationKeys.VALID_OFFLINE_FEE_SETTLEMENT_VKEY, (VerificationKey));
+        BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
+        return VerifierCore.verify(proof, publicInputs, vk);
+    }
+
+    /// @notice Verify a proof of `VALID FEE REDEMPTION`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidFeeRedemption(
+        ValidFeeRedemptionStatement calldata statement,
+        PlonkProof calldata proof
+    )
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = abi.decode(VerificationKeys.VALID_FEE_REDEMPTION_VKEY, (VerificationKey));
         BN254.ScalarField[] memory publicInputs = statement.scalarSerialize();
         return VerifierCore.verify(proof, publicInputs, vk);
     }

--- a/src/libraries/darkpool/WalletOperations.sol
+++ b/src/libraries/darkpool/WalletOperations.sol
@@ -98,6 +98,27 @@ library WalletOperations {
         return BN254.ScalarField.wrap(walletCommitment);
     }
 
+    /// @notice Spend a note
+    /// @dev This involves both checking the note's inclusion root and spending its nullifier
+    /// @param noteNullifier The nullifier of the note
+    /// @param noteRoot The root of the note
+    /// @param nullifierSet The set of nullifiers for the darkpool
+    /// @param merkleTree The merkle tree for the darkpool
+    function spendNote(
+        BN254.ScalarField noteNullifier,
+        BN254.ScalarField noteRoot,
+        NullifierLib.NullifierSet storage nullifierSet,
+        MerkleTreeLib.MerkleTree storage merkleTree
+    )
+        internal
+    {
+        // 1. Check that the note is in the Merkle tree
+        require(merkleTree.rootInHistory(noteRoot), "Note not in Merkle history");
+
+        // 2. Spend the note
+        nullifierSet.spend(noteNullifier);
+    }
+
     /// @notice Verify a wallet update signature
     /// @dev The signature is expected in the following format:
     /// @dev r || s || v, for a total of 65 bytes where:

--- a/src/libraries/interfaces/IVerifier.sol
+++ b/src/libraries/interfaces/IVerifier.sol
@@ -7,7 +7,8 @@ import {
     ValidWalletUpdateStatement,
     ValidMatchSettleStatement,
     ValidMatchSettleAtomicStatement,
-    ValidOfflineFeeSettlementStatement
+    ValidOfflineFeeSettlementStatement,
+    ValidFeeRedemptionStatement
 } from "renegade/libraries/darkpool/PublicInputs.sol";
 import {
     PartyMatchPayload,
@@ -81,6 +82,18 @@ interface IVerifier {
     /// @return True if the proof is valid, false otherwise
     function verifyValidOfflineFeeSettlement(
         ValidOfflineFeeSettlementStatement calldata statement,
+        PlonkProof calldata proof
+    )
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `VALID FEE REDEMPTION`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True if the proof is valid, false otherwise
+    function verifyValidFeeRedemption(
+        ValidFeeRedemptionStatement calldata statement,
         PlonkProof calldata proof
     )
         external

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -8,6 +8,7 @@ import {
     ValidMatchSettleStatement,
     ValidMatchSettleAtomicStatement,
     ValidOfflineFeeSettlementStatement,
+    ValidFeeRedemptionStatement,
     StatementSerializer
 } from "renegade/libraries/darkpool/PublicInputs.sol";
 import {
@@ -119,6 +120,22 @@ contract TestVerifier is IVerifier {
         returns (bool)
     {
         verifier.verifyValidOfflineFeeSettlement(statement, proof);
+        return true;
+    }
+
+    /// @notice Verify a proof of `VALID FEE REDEMPTION`
+    /// @param statement The public inputs to the proof
+    /// @param proof The proof to verify
+    /// @return True always, regardless of the proof
+    function verifyValidFeeRedemption(
+        ValidFeeRedemptionStatement calldata statement,
+        PlonkProof calldata proof
+    )
+        external
+        view
+        returns (bool)
+    {
+        verifier.verifyValidFeeRedemption(statement, proof);
         return true;
     }
 }


### PR DESCRIPTION
### Purpose
This PR implements the `redeemFee` method on the darkpool contract. This method is used to redeem a note into a wallet after it has been committed by a previous `settleOfflineFee` txn. Embedded in the proof of `VALID FEE REDEMPTION` is a PoK of the decryption key associated with the `receiver` field on the note.

### Todo
- Test suite for `redeemFee`

### Testing
- [x] All existing tests pass