### PR TITLE
libraries: darkpool: WalletOperations: Modify shares for malleable match

### DIFF
--- a/src/libraries/darkpool/Constants.sol
+++ b/src/libraries/darkpool/Constants.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { MAX_ORDERS as WALLET_MAX_ORDERS, MAX_BALANCES as WALLET_MAX_BALANCES } from "./types/Wallet.sol";
+import {
+    MAX_ORDERS as WALLET_MAX_ORDERS,
+    MAX_BALANCES as WALLET_MAX_BALANCES,
+    NUM_WALLET_SCALARS
+} from "./types/Wallet.sol";
 
 /// @title Darkpool Constants
 /// @notice Constants used in the darkpool
@@ -11,7 +15,7 @@ library DarkpoolConstants {
     /// @notice The maximum number of balances in a wallet
     uint256 constant MAX_BALANCES = WALLET_MAX_BALANCES;
     /// @notice The number of shares in a wallet
-    uint256 constant N_WALLET_SHARES = 70;
+    uint256 constant N_WALLET_SHARES = NUM_WALLET_SCALARS;
     /// @notice The depth of the Merkle tree
     uint256 constant MERKLE_DEPTH = 32;
     /// @notice The maximum number of leaves in the merkle tree

--- a/src/libraries/darkpool/types/Keychain.sol
+++ b/src/libraries/darkpool/types/Keychain.sol
@@ -44,5 +44,5 @@ struct PublicKeychain {
     /// @dev The relayer proves knowledge of preimage to authorize matches it generates
     PublicIdentificationKey pkMatch;
     /// @dev The nonce of the keychain, allowing the keychain to be rotated, then separate recovered
-    uint256 nonce;
+    BN254.ScalarField nonce;
 }

--- a/src/libraries/darkpool/types/TypesLib.sol
+++ b/src/libraries/darkpool/types/TypesLib.sol
@@ -53,7 +53,7 @@ library TypesLib {
     /// @param scalar The scalar to multiply by
     /// @return The truncated result of the multiplication
     function unsafeFixedPointMul(FixedPoint memory self, uint256 scalar) public pure returns (uint256) {
-        return (self.repr * scalar) / DarkpoolConstants.FIXED_POINT_PRECISION_BITS;
+        return (self.repr * scalar) / (1 << DarkpoolConstants.FIXED_POINT_PRECISION_BITS);
     }
 
     // --- External Transfers --- //

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -12,6 +12,13 @@ contract TestUtils is Test {
     /// @dev The scalar field modulus for K256
     uint256 constant K256_SCALAR_MOD = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141;
 
+    // --- Assertions --- //
+
+    /// @dev Assert that two BN254 scalar fields are equal
+    function assertEq(BN254.ScalarField a, BN254.ScalarField b) internal {
+        assertEq(BN254.ScalarField.unwrap(a), BN254.ScalarField.unwrap(b));
+    }
+
     // --- Fuzzing Helpers --- //
 
     /// @dev Generates a random byte


### PR DESCRIPTION
### Purpose
This PR adds a helper to modify a wallet's shares in settling a malleable atomic match. This reduces the order volume, decreases the send balance, increases the receiver balance, and increases the fees accumulated on the receive balance.

### Testing
- [x] All unit tests pass
- [x] Added tests for both buy and sell side settlement, both pass