### PR TITLE
test: darkpool: SettleMalleableAtomicMatch: Add valid match tests

### DIFF
--- a/src/libraries/darkpool/PublicInputs.sol
+++ b/src/libraries/darkpool/PublicInputs.sol
@@ -557,7 +557,7 @@ library StatementSerializer {
     /// @param self The result to serialize
     /// @return serialized The serialized result as an array of scalar field elements
     function scalarSerialize(BoundedMatchResult memory self) internal pure returns (BN254.ScalarField[] memory) {
-        BN254.ScalarField[] memory serialized = new BN254.ScalarField[](5);
+        BN254.ScalarField[] memory serialized = new BN254.ScalarField[](6);
 
         serialized[0] = BN254.ScalarField.wrap(uint256(uint160(self.quoteMint)));
         serialized[1] = BN254.ScalarField.wrap(uint256(uint160(self.baseMint)));

--- a/src/libraries/darkpool/WalletOperations.sol
+++ b/src/libraries/darkpool/WalletOperations.sol
@@ -11,7 +11,6 @@ import { ExternalMatchResult, OrderSettlementIndices } from "renegade-lib/darkpo
 import { FeeTakeRate, FeeTake } from "renegade-lib/darkpool/types/Fees.sol";
 import { BalanceShare } from "renegade-lib/darkpool/types/Wallet.sol";
 import { TypesLib } from "renegade-lib/darkpool/types/TypesLib.sol";
-import { console2 } from "forge-std/console2.sol";
 
 // --- Helpers --- //
 

--- a/test/Merkle.t.sol
+++ b/test/Merkle.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { Test } from "forge-std/Test.sol";
-import { console } from "forge-std/console.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { TestUtils } from "./utils/TestUtils.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";

--- a/test/Poseidon.t.sol
+++ b/test/Poseidon.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { Test } from "forge-std/Test.sol";
-import { console } from "forge-std/console.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 import { TestUtils } from "./utils/TestUtils.sol";
 

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -43,7 +43,7 @@ contract DarkpoolTestBase is CalldataUtils {
     bytes constant INVALID_ETH_VALUE_REVERT_STRING = "Invalid ETH value, should be zero unless selling native token";
     bytes constant INVALID_ETH_DEPOSIT_AMOUNT_REVERT_STRING = "msg.value does not match deposit amount";
 
-    function setUp() public {
+    function setUp() public virtual {
         // Deploy a Permit2 instance for testing
         DeployPermit2 permit2Deployer = new DeployPermit2();
         permit2 = IPermit2(permit2Deployer.deployPermit2());
@@ -62,6 +62,24 @@ contract DarkpoolTestBase is CalldataUtils {
         protocolFeeAddr = vm.randomAddress();
         EncryptionKey memory protocolFeeKey = randomEncryptionKey();
         darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, verifier, permit2);
+    }
+
+    /// @dev Get the base and quote token amounts for an address
+    function baseQuoteBalances(address addr) public view returns (uint256 baseAmt, uint256 quoteAmt) {
+        baseAmt = baseToken.balanceOf(addr);
+        quoteAmt = quoteToken.balanceOf(addr);
+    }
+
+    /// @dev Get the weth and quote token balances for an address
+    function wethQuoteBalances(address addr) public view returns (uint256 wethAmt, uint256 quoteAmt) {
+        wethAmt = weth.balanceOf(addr);
+        quoteAmt = quoteToken.balanceOf(addr);
+    }
+
+    /// @dev Get the ether and quote token balances for an address
+    function etherQuoteBalances(address addr) public view returns (uint256 etherAmt, uint256 quoteAmt) {
+        etherAmt = addr.balance;
+        quoteAmt = quoteToken.balanceOf(addr);
     }
 
     // ---------------------------

--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -37,15 +37,10 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         // Setup tokens
         quoteToken.mint(externalParty.addr, QUOTE_AMT);
         baseToken.mint(address(darkpool), BASE_AMT);
-
-        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
-        uint256 relayerInitialQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
-        uint256 relayerInitialBaseBalance = baseToken.balanceOf(relayerFeeAddr);
-        uint256 protocolInitialQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
-        uint256 protocolInitialBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+        (uint256 userBaseBalance1, uint256 userQuoteBalance1) = baseQuoteBalances(externalParty.addr);
+        (uint256 darkpoolBaseBalance1, uint256 darkpoolQuoteBalance1) = baseQuoteBalances(address(darkpool));
+        (uint256 relayerBaseBalance1, uint256 relayerQuoteBalance1) = baseQuoteBalances(relayerFeeAddr);
+        (uint256 protocolBaseBalance1, uint256 protocolQuoteBalance1) = baseQuoteBalances(protocolFeeAddr);
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -78,23 +73,19 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         assert(totalFee > 0); // Make sure we're testing fees
         uint256 expectedBaseAmt = BASE_AMT - totalFee;
 
-        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
-        uint256 relayerFinalQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
-        uint256 relayerFinalBaseBalance = baseToken.balanceOf(relayerFeeAddr);
-        uint256 protocolFinalQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
-        uint256 protocolFinalBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+        (uint256 userBaseBalance2, uint256 userQuoteBalance2) = baseQuoteBalances(externalParty.addr);
+        (uint256 darkpoolBaseBalance2, uint256 darkpoolQuoteBalance2) = baseQuoteBalances(address(darkpool));
+        (uint256 relayerBaseBalance2, uint256 relayerQuoteBalance2) = baseQuoteBalances(relayerFeeAddr);
+        (uint256 protocolBaseBalance2, uint256 protocolQuoteBalance2) = baseQuoteBalances(protocolFeeAddr);
 
-        assertEq(userFinalQuoteBalance, userInitialQuoteBalance - QUOTE_AMT);
-        assertEq(userFinalBaseBalance, userInitialBaseBalance + expectedBaseAmt);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance + QUOTE_AMT);
-        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance - BASE_AMT);
-        assertEq(relayerFinalQuoteBalance, relayerInitialQuoteBalance);
-        assertEq(relayerFinalBaseBalance, relayerInitialBaseBalance + fees.relayerFee);
-        assertEq(protocolFinalQuoteBalance, protocolInitialQuoteBalance);
-        assertEq(protocolFinalBaseBalance, protocolInitialBaseBalance + fees.protocolFee);
+        assertEq(userQuoteBalance2, userQuoteBalance1 - QUOTE_AMT);
+        assertEq(userBaseBalance2, userBaseBalance1 + expectedBaseAmt);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 + QUOTE_AMT);
+        assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 - BASE_AMT);
+        assertEq(relayerQuoteBalance2, relayerQuoteBalance1);
+        assertEq(relayerBaseBalance2, relayerBaseBalance1 + fees.relayerFee);
+        assertEq(protocolQuoteBalance2, protocolQuoteBalance1);
+        assertEq(protocolBaseBalance2, protocolBaseBalance1 + fees.protocolFee);
     }
 
     /// @notice Test settling an atomic match with the external party sell side
@@ -106,15 +97,10 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         // Setup tokens
         quoteToken.mint(address(darkpool), QUOTE_AMT);
         baseToken.mint(externalParty.addr, BASE_AMT);
-
-        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
-        uint256 relayerInitialQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
-        uint256 relayerInitialBaseBalance = baseToken.balanceOf(relayerFeeAddr);
-        uint256 protocolInitialQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
-        uint256 protocolInitialBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+        (uint256 userBaseBalance1, uint256 userQuoteBalance1) = baseQuoteBalances(externalParty.addr);
+        (uint256 darkpoolBaseBalance1, uint256 darkpoolQuoteBalance1) = baseQuoteBalances(address(darkpool));
+        (uint256 relayerBaseBalance1, uint256 relayerQuoteBalance1) = baseQuoteBalances(relayerFeeAddr);
+        (uint256 protocolBaseBalance1, uint256 protocolQuoteBalance1) = baseQuoteBalances(protocolFeeAddr);
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -146,23 +132,19 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         uint256 totalFee = fees.total();
         uint256 expectedQuoteAmt = QUOTE_AMT - totalFee;
 
-        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
-        uint256 relayerFinalQuoteBalance = quoteToken.balanceOf(relayerFeeAddr);
-        uint256 relayerFinalBaseBalance = baseToken.balanceOf(relayerFeeAddr);
-        uint256 protocolFinalQuoteBalance = quoteToken.balanceOf(protocolFeeAddr);
-        uint256 protocolFinalBaseBalance = baseToken.balanceOf(protocolFeeAddr);
+        (uint256 userBaseBalance2, uint256 userQuoteBalance2) = baseQuoteBalances(externalParty.addr);
+        (uint256 darkpoolBaseBalance2, uint256 darkpoolQuoteBalance2) = baseQuoteBalances(address(darkpool));
+        (uint256 relayerBaseBalance2, uint256 relayerQuoteBalance2) = baseQuoteBalances(relayerFeeAddr);
+        (uint256 protocolBaseBalance2, uint256 protocolQuoteBalance2) = baseQuoteBalances(protocolFeeAddr);
 
-        assertEq(userFinalQuoteBalance, userInitialQuoteBalance + expectedQuoteAmt);
-        assertEq(userFinalBaseBalance, userInitialBaseBalance - BASE_AMT);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance - QUOTE_AMT);
-        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance + BASE_AMT);
-        assertEq(relayerFinalQuoteBalance, relayerInitialQuoteBalance + fees.relayerFee);
-        assertEq(relayerFinalBaseBalance, relayerInitialBaseBalance);
-        assertEq(protocolFinalQuoteBalance, protocolInitialQuoteBalance + fees.protocolFee);
-        assertEq(protocolFinalBaseBalance, protocolInitialBaseBalance);
+        assertEq(userQuoteBalance2, userQuoteBalance1 + expectedQuoteAmt);
+        assertEq(userBaseBalance2, userBaseBalance1 - BASE_AMT);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 - QUOTE_AMT);
+        assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 + BASE_AMT);
+        assertEq(relayerQuoteBalance2, relayerQuoteBalance1 + fees.relayerFee);
+        assertEq(relayerBaseBalance2, relayerBaseBalance1);
+        assertEq(protocolQuoteBalance2, protocolQuoteBalance1 + fees.protocolFee);
+        assertEq(protocolBaseBalance2, protocolBaseBalance1);
     }
 
     /// @notice Test settling an atomic match with a non-sender receiver specified
@@ -173,12 +155,9 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         // Setup tokens
         quoteToken.mint(externalParty.addr, QUOTE_AMT);
         baseToken.mint(address(darkpool), BASE_AMT);
-        uint256 senderInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 senderInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 receiverInitialQuoteBalance = quoteToken.balanceOf(receiver);
-        uint256 receiverInitialBaseBalance = baseToken.balanceOf(receiver);
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
+        (uint256 senderBaseBalance1, uint256 senderQuoteBalance1) = baseQuoteBalances(externalParty.addr);
+        (uint256 receiverBaseBalance1, uint256 receiverQuoteBalance1) = baseQuoteBalances(receiver);
+        (uint256 darkpoolBaseBalance1, uint256 darkpoolQuoteBalance1) = baseQuoteBalances(address(darkpool));
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -209,19 +188,16 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         uint256 totalFee = fees.total();
         uint256 expectedBaseAmt = BASE_AMT - totalFee;
 
-        uint256 senderFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 senderFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 receiverFinalQuoteBalance = quoteToken.balanceOf(receiver);
-        uint256 receiverFinalBaseBalance = baseToken.balanceOf(receiver);
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
+        (uint256 senderBaseBalance2, uint256 senderQuoteBalance2) = baseQuoteBalances(externalParty.addr);
+        (uint256 receiverBaseBalance2, uint256 receiverQuoteBalance2) = baseQuoteBalances(receiver);
+        (uint256 darkpoolBaseBalance2, uint256 darkpoolQuoteBalance2) = baseQuoteBalances(address(darkpool));
 
-        assertEq(senderFinalQuoteBalance, senderInitialQuoteBalance - QUOTE_AMT);
-        assertEq(senderFinalBaseBalance, senderInitialBaseBalance);
-        assertEq(receiverFinalQuoteBalance, receiverInitialQuoteBalance);
-        assertEq(receiverFinalBaseBalance, receiverInitialBaseBalance + expectedBaseAmt);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance + QUOTE_AMT);
-        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance - BASE_AMT);
+        assertEq(senderQuoteBalance2, senderQuoteBalance1 - QUOTE_AMT);
+        assertEq(senderBaseBalance2, senderBaseBalance1);
+        assertEq(receiverQuoteBalance2, receiverQuoteBalance1);
+        assertEq(receiverBaseBalance2, receiverBaseBalance1 + expectedBaseAmt);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 + QUOTE_AMT);
+        assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 - BASE_AMT);
     }
 
     /// @notice Test settling an atomic match with a non-sender receiver specified
@@ -232,12 +208,9 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         // Setup tokens
         quoteToken.mint(address(darkpool), QUOTE_AMT);
         baseToken.mint(externalParty.addr, BASE_AMT);
-        uint256 senderInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 senderInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 receiverInitialQuoteBalance = quoteToken.balanceOf(receiver);
-        uint256 receiverInitialBaseBalance = baseToken.balanceOf(receiver);
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
+        (uint256 senderBaseBalance1, uint256 senderQuoteBalance1) = baseQuoteBalances(externalParty.addr);
+        (uint256 receiverBaseBalance1, uint256 receiverQuoteBalance1) = baseQuoteBalances(receiver);
+        (uint256 darkpoolBaseBalance1, uint256 darkpoolQuoteBalance1) = baseQuoteBalances(address(darkpool));
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -268,19 +241,16 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         uint256 totalFee = fees.total();
         uint256 expectedQuoteAmt = QUOTE_AMT - totalFee;
 
-        uint256 senderFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 senderFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 receiverFinalQuoteBalance = quoteToken.balanceOf(receiver);
-        uint256 receiverFinalBaseBalance = baseToken.balanceOf(receiver);
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
+        (uint256 senderBaseBalance2, uint256 senderQuoteBalance2) = baseQuoteBalances(externalParty.addr);
+        (uint256 receiverBaseBalance2, uint256 receiverQuoteBalance2) = baseQuoteBalances(receiver);
+        (uint256 darkpoolBaseBalance2, uint256 darkpoolQuoteBalance2) = baseQuoteBalances(address(darkpool));
 
-        assertEq(senderFinalQuoteBalance, senderInitialQuoteBalance);
-        assertEq(senderFinalBaseBalance, senderInitialBaseBalance - BASE_AMT);
-        assertEq(receiverFinalQuoteBalance, receiverInitialQuoteBalance + expectedQuoteAmt);
-        assertEq(receiverFinalBaseBalance, receiverInitialBaseBalance);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance - QUOTE_AMT);
-        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance + BASE_AMT);
+        assertEq(senderQuoteBalance2, senderQuoteBalance1);
+        assertEq(senderBaseBalance2, senderBaseBalance1 - BASE_AMT);
+        assertEq(receiverQuoteBalance2, receiverQuoteBalance1 + expectedQuoteAmt);
+        assertEq(receiverBaseBalance2, receiverBaseBalance1);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 - QUOTE_AMT);
+        assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 + BASE_AMT);
     }
 
     /// @notice Test settling an atomic match with a native token, buy side
@@ -291,10 +261,8 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         quoteToken.mint(externalParty.addr, QUOTE_AMT);
         weth.mint(address(darkpool), BASE_AMT);
 
-        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userInitialNativeBalance = externalParty.addr.balance;
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialWethBalance = weth.balanceOf(address(darkpool));
+        (uint256 userNativeBalance1, uint256 userQuoteBalance1) = etherQuoteBalances(externalParty.addr);
+        (uint256 darkpoolWethBalance1, uint256 darkpoolQuoteBalance1) = wethQuoteBalances(address(darkpool));
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -325,15 +293,13 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         uint256 totalFee = fees.total();
         uint256 expectedBaseAmt = BASE_AMT - totalFee;
 
-        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userFinalNativeBalance = externalParty.addr.balance;
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalWethBalance = weth.balanceOf(address(darkpool));
+        (uint256 userNativeBalance2, uint256 userQuoteBalance2) = etherQuoteBalances(externalParty.addr);
+        (uint256 darkpoolWethBalance2, uint256 darkpoolQuoteBalance2) = wethQuoteBalances(address(darkpool));
 
-        assertEq(userFinalQuoteBalance, userInitialQuoteBalance - QUOTE_AMT);
-        assertEq(userFinalNativeBalance, userInitialNativeBalance + expectedBaseAmt);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance + QUOTE_AMT);
-        assertEq(darkpoolFinalWethBalance, darkpoolInitialWethBalance - BASE_AMT);
+        assertEq(userQuoteBalance2, userQuoteBalance1 - QUOTE_AMT);
+        assertEq(userNativeBalance2, userNativeBalance1 + expectedBaseAmt);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 + QUOTE_AMT);
+        assertEq(darkpoolWethBalance2, darkpoolWethBalance1 - BASE_AMT);
     }
 
     /// @notice Test settling an atomic match with a native token, sell side
@@ -343,11 +309,8 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         // Setup tokens
         vm.deal(externalParty.addr, BASE_AMT);
         quoteToken.mint(address(darkpool), QUOTE_AMT);
-
-        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userInitialNativeBalance = externalParty.addr.balance;
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialWethBalance = weth.balanceOf(address(darkpool));
+        (uint256 userNativeBalance1, uint256 userQuoteBalance1) = etherQuoteBalances(externalParty.addr);
+        (uint256 darkpoolWethBalance1, uint256 darkpoolQuoteBalance1) = wethQuoteBalances(address(darkpool));
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -377,15 +340,13 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         uint256 totalFee = fees.total();
         uint256 expectedQuoteAmt = QUOTE_AMT - totalFee;
 
-        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userFinalNativeBalance = externalParty.addr.balance;
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalWethBalance = weth.balanceOf(address(darkpool));
+        (uint256 userNativeBalance2, uint256 userQuoteBalance2) = etherQuoteBalances(externalParty.addr);
+        (uint256 darkpoolWethBalance2, uint256 darkpoolQuoteBalance2) = wethQuoteBalances(address(darkpool));
 
-        assertEq(userFinalQuoteBalance, userInitialQuoteBalance + expectedQuoteAmt);
-        assertEq(userFinalNativeBalance, userInitialNativeBalance - BASE_AMT);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance - QUOTE_AMT);
-        assertEq(darkpoolFinalWethBalance, darkpoolInitialWethBalance + BASE_AMT);
+        assertEq(userQuoteBalance2, userQuoteBalance1 + expectedQuoteAmt);
+        assertEq(userNativeBalance2, userNativeBalance1 - BASE_AMT);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 - QUOTE_AMT);
+        assertEq(darkpoolWethBalance2, darkpoolWethBalance1 + BASE_AMT);
     }
 
     /// @notice Test settling an atomic match with a non-default protocol fee rate
@@ -403,10 +364,8 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         Vm.Wallet memory externalParty = randomEthereumWallet();
         baseToken.mint(externalParty.addr, BASE_AMT);
         quoteToken.mint(address(darkpool), QUOTE_AMT);
-        uint256 userInitialQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userInitialBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 darkpoolInitialQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolInitialBaseBalance = baseToken.balanceOf(address(darkpool));
+        (uint256 userBaseBalance1, uint256 userQuoteBalance1) = baseQuoteBalances(externalParty.addr);
+        (uint256 darkpoolBaseBalance1, uint256 darkpoolQuoteBalance1) = baseQuoteBalances(address(darkpool));
 
         // Setup the match
         ExternalMatchResult memory matchResult = ExternalMatchResult({
@@ -439,15 +398,13 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
         uint256 totalFee = newFees.total();
         uint256 expectedQuoteAmt = QUOTE_AMT - totalFee;
 
-        uint256 userFinalQuoteBalance = quoteToken.balanceOf(externalParty.addr);
-        uint256 userFinalBaseBalance = baseToken.balanceOf(externalParty.addr);
-        uint256 darkpoolFinalQuoteBalance = quoteToken.balanceOf(address(darkpool));
-        uint256 darkpoolFinalBaseBalance = baseToken.balanceOf(address(darkpool));
+        (uint256 userBaseBalance2, uint256 userQuoteBalance2) = baseQuoteBalances(externalParty.addr);
+        (uint256 darkpoolBaseBalance2, uint256 darkpoolQuoteBalance2) = baseQuoteBalances(address(darkpool));
 
-        assertEq(userFinalQuoteBalance, userInitialQuoteBalance + expectedQuoteAmt);
-        assertEq(userFinalBaseBalance, userInitialBaseBalance - BASE_AMT);
-        assertEq(darkpoolFinalQuoteBalance, darkpoolInitialQuoteBalance - QUOTE_AMT);
-        assertEq(darkpoolFinalBaseBalance, darkpoolInitialBaseBalance + BASE_AMT);
+        assertEq(userQuoteBalance2, userQuoteBalance1 + expectedQuoteAmt);
+        assertEq(userBaseBalance2, userBaseBalance1 - BASE_AMT);
+        assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 - QUOTE_AMT);
+        assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 + BASE_AMT);
     }
 
     // --- Invalid Match Tests --- //

--- a/test/darkpool/SettleMalleableAtomicMatch.t.sol
+++ b/test/darkpool/SettleMalleableAtomicMatch.t.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+import { Test } from "forge-std/Test.sol";
+import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import {
+    PartyMatchPayload,
+    MalleableMatchAtomicProofs,
+    MatchAtomicLinkingProofs
+} from "renegade-lib/darkpool/types/Settlement.sol";
+import { TypesLib } from "renegade-lib/darkpool/types/TypesLib.sol";
+import { FeeTake, FeeTakeRate } from "renegade-lib/darkpool/types/Fees.sol";
+import {
+    ExternalMatchDirection, BoundedMatchResult, ExternalMatchResult
+} from "renegade-lib/darkpool/types/Settlement.sol";
+import { ValidMalleableMatchSettleAtomicStatement } from "renegade-lib/darkpool/PublicInputs.sol";
+
+contract SettleMalleableAtomicMatch is DarkpoolTestBase {
+    using TypesLib for FeeTake;
+    using TypesLib for FeeTakeRate;
+    using TypesLib for BoundedMatchResult;
+
+    address public txSender;
+    address public relayerFeeAddr;
+
+    function setUp() public override {
+        super.setUp();
+        txSender = vm.randomAddress();
+        relayerFeeAddr = vm.randomAddress();
+    }
+
+    // --- Valid Match Tests --- //
+
+    /// @notice Test settling a malleable atomic match with the external party buy side
+    function test_settleMalleableAtomicMatch_externalPartyBuySide() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = genMalleableMatchCalldata(ExternalMatchDirection.InternalPartySell, merkleRoot);
+
+        // Fund the external party and darkpool
+        ExternalMatchResult memory externalMatchResult = sampleExternalMatch(statement.matchResult);
+        fundExternalPartyAndDarkpool(externalMatchResult);
+        verifyMalleableAtomicMatch(
+            externalMatchResult.baseAmount, internalPartyPayload, statement, proofs, linkingProofs
+        );
+    }
+
+    /// @notice Test settling a malleable atomic match with the external party sell side
+    function test_settleMalleableAtomicMatch_externalPartySellSide() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = genMalleableMatchCalldata(ExternalMatchDirection.InternalPartyBuy, merkleRoot);
+
+        // Fund the external party and darkpool
+        ExternalMatchResult memory externalMatchResult = sampleExternalMatch(statement.matchResult);
+        fundExternalPartyAndDarkpool(externalMatchResult);
+
+        verifyMalleableAtomicMatch(
+            externalMatchResult.baseAmount, internalPartyPayload, statement, proofs, linkingProofs
+        );
+    }
+
+    // --- Helper Functions --- //
+
+    /// @notice Sample a random base amount between the bounds on a `BoundedMatchResult`
+    function sampleBaseAmount(BoundedMatchResult memory matchResult) internal returns (uint256) {
+        uint256 min = matchResult.minBaseAmount;
+        uint256 max = matchResult.maxBaseAmount;
+        return randomUint(min, max);
+    }
+
+    /// @notice Sample an external match from a bounded match
+    function sampleExternalMatch(BoundedMatchResult memory matchResult) internal returns (ExternalMatchResult memory) {
+        uint256 baseAmt = sampleBaseAmount(matchResult);
+        return TypesLib.buildExternalMatchResult(baseAmt, matchResult);
+    }
+
+    /// @notice Fund the external party and darkpool given a match result
+    function fundExternalPartyAndDarkpool(ExternalMatchResult memory externalMatchResult) internal {
+        (address sellMint, uint256 sellAmt) = TypesLib.externalPartySellMintAmount(externalMatchResult);
+        (address buyMint, uint256 buyAmt) = TypesLib.externalPartyBuyMintAmount(externalMatchResult);
+
+        // Fund the external party and darkpool
+        ERC20Mock sellToken = ERC20Mock(sellMint);
+        ERC20Mock buyToken = ERC20Mock(buyMint);
+        sellToken.mint(txSender, sellAmt);
+        buyToken.mint(address(darkpool), buyAmt);
+
+        // Approve the darkpool to spend the tokens
+        vm.startBroadcast(txSender);
+        sellToken.approve(address(darkpool), sellAmt);
+        vm.stopBroadcast();
+    }
+
+    /// @notice Generate the calldata for settling a malleable atomic match, using the testing contracts
+    /// @param direction The direction of the match
+    /// @param merkleRoot The merkle root of the darkpool
+    /// @return internalPartyPayload The internal party payload
+    /// @return statement The statement
+    /// @return proofs The proofs
+    /// @return linkingProofs The linking proofs
+    function genMalleableMatchCalldata(
+        ExternalMatchDirection direction,
+        BN254.ScalarField merkleRoot
+    )
+        internal
+        returns (
+            PartyMatchPayload memory,
+            ValidMalleableMatchSettleAtomicStatement memory,
+            MalleableMatchAtomicProofs memory,
+            MatchAtomicLinkingProofs memory
+        )
+    {
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleMalleableAtomicMatchCalldata(direction, merkleRoot);
+
+        // Modify the pair to be the quote and base token setup by the test harness
+        statement.matchResult.quoteMint = address(quoteToken);
+        statement.matchResult.baseMint = address(baseToken);
+        statement.relayerFeeAddress = relayerFeeAddr;
+
+        return (internalPartyPayload, statement, proofs, linkingProofs);
+    }
+
+    /// @notice Submit a malleable atomic match and check the token flows
+    function verifyMalleableAtomicMatch(
+        uint256 baseAmount,
+        PartyMatchPayload memory internalPartyPayload,
+        ValidMalleableMatchSettleAtomicStatement memory statement,
+        MalleableMatchAtomicProofs memory proofs,
+        MatchAtomicLinkingProofs memory linkingProofs
+    )
+        internal
+    {
+        // Get the balances before the match
+        (uint256 userBaseBalance1, uint256 userQuoteBalance1) = baseQuoteBalances(txSender);
+        (uint256 darkpoolBaseBalance1, uint256 darkpoolQuoteBalance1) = baseQuoteBalances(address(darkpool));
+        (uint256 relayerBaseBalance1, uint256 relayerQuoteBalance1) = baseQuoteBalances(relayerFeeAddr);
+        (uint256 protocolBaseBalance1, uint256 protocolQuoteBalance1) = baseQuoteBalances(protocolFeeAddr);
+
+        // Submit the match
+        vm.startBroadcast(txSender);
+        address receiver = txSender;
+        darkpool.processMalleableAtomicMatchSettle(
+            baseAmount, receiver, internalPartyPayload, statement, proofs, linkingProofs
+        );
+        vm.stopBroadcast();
+
+        // Get the balances after the match
+        (uint256 userBaseBalance2, uint256 userQuoteBalance2) = baseQuoteBalances(txSender);
+        (uint256 darkpoolBaseBalance2, uint256 darkpoolQuoteBalance2) = baseQuoteBalances(address(darkpool));
+        (uint256 relayerBaseBalance2, uint256 relayerQuoteBalance2) = baseQuoteBalances(relayerFeeAddr);
+        (uint256 protocolBaseBalance2, uint256 protocolQuoteBalance2) = baseQuoteBalances(protocolFeeAddr);
+
+        ExternalMatchResult memory externalMatchResult =
+            TypesLib.buildExternalMatchResult(baseAmount, statement.matchResult);
+
+        // Check the token flows
+        uint256 baseAmt = externalMatchResult.baseAmount;
+        uint256 quoteAmt = externalMatchResult.quoteAmount;
+
+        if (externalMatchResult.direction == ExternalMatchDirection.InternalPartySell) {
+            FeeTake memory externalPartyFees = statement.externalFeeRates.computeFeeTake(baseAmt);
+
+            // External party buys the base, sells the quote
+            assertEq(userBaseBalance2, userBaseBalance1 + baseAmt - externalPartyFees.total());
+            assertEq(userQuoteBalance2, userQuoteBalance1 - quoteAmt);
+            assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 - baseAmt);
+            assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 + quoteAmt);
+            assertEq(relayerBaseBalance2, relayerBaseBalance1 + externalPartyFees.relayerFee);
+            assertEq(relayerQuoteBalance2, relayerQuoteBalance1);
+            assertEq(protocolBaseBalance2, protocolBaseBalance1 + externalPartyFees.protocolFee);
+            assertEq(protocolQuoteBalance2, protocolQuoteBalance1);
+        } else {
+            FeeTake memory externalPartyFees = statement.externalFeeRates.computeFeeTake(quoteAmt);
+
+            // External party buys the quote, sells the base
+            assertEq(userBaseBalance2, userBaseBalance1 - baseAmt);
+            assertEq(userQuoteBalance2, userQuoteBalance1 + quoteAmt - externalPartyFees.total());
+            assertEq(darkpoolBaseBalance2, darkpoolBaseBalance1 + baseAmt);
+            assertEq(darkpoolQuoteBalance2, darkpoolQuoteBalance1 - quoteAmt);
+            assertEq(relayerBaseBalance2, relayerBaseBalance1);
+            assertEq(relayerQuoteBalance2, relayerQuoteBalance1 + externalPartyFees.relayerFee);
+            assertEq(protocolBaseBalance2, protocolBaseBalance1);
+            assertEq(protocolQuoteBalance2, protocolQuoteBalance1 + externalPartyFees.protocolFee);
+        }
+    }
+}

--- a/test/libraries/darkpool/Wallet.t.sol
+++ b/test/libraries/darkpool/Wallet.t.sol
@@ -16,9 +16,9 @@ import { FeeTakeRate, FeeTake } from "renegade-lib/darkpool/types/Fees.sol";
 import { TypesLib } from "renegade-lib/darkpool/types/TypesLib.sol";
 import { DarkpoolConstants } from "renegade-lib/darkpool/Constants.sol";
 import { WalletOperations } from "renegade-lib/darkpool/WalletOperations.sol";
-import { TestUtils } from "test/utils/TestUtils.sol";
+import { CalldataUtils } from "test/utils/CalldataUtils.sol";
 
-contract WalletTest is TestUtils {
+contract WalletTest is CalldataUtils {
     using BN254 for BN254.ScalarField;
     using WalletLib for WalletShare;
     using TypesLib for FeeTakeRate;
@@ -111,47 +111,5 @@ contract WalletTest is TestUtils {
     function randomWalletShare() internal returns (WalletShare memory) {
         BN254.ScalarField[] memory scalars = randomWalletShares();
         return WalletLib.scalarDeserialize(scalars);
-    }
-
-    /// @dev Generate a random external match result
-    function randomExternalMatchResult(ExternalMatchDirection direction)
-        internal
-        returns (ExternalMatchResult memory matchResult)
-    {
-        matchResult = ExternalMatchResult({
-            baseMint: vm.randomAddress(),
-            quoteMint: vm.randomAddress(),
-            baseAmount: randomAmount(),
-            quoteAmount: randomAmount(),
-            direction: direction
-        });
-    }
-
-    /// @dev Generate a random set of order settlement indices
-    function randomOrderSettlementIndices() internal returns (OrderSettlementIndices memory indices) {
-        uint256 bal1 = randomUint(DarkpoolConstants.MAX_BALANCES);
-        uint256 bal2 = randomUint(DarkpoolConstants.MAX_BALANCES);
-        while (bal2 == bal1) {
-            bal2 = randomUint(DarkpoolConstants.MAX_BALANCES);
-        }
-        uint256 order = randomUint(DarkpoolConstants.MAX_ORDERS);
-
-        indices = OrderSettlementIndices({ balanceSend: bal1, balanceReceive: bal2, order: order });
-    }
-
-    /// @dev Generate a random fee take rate
-    function randomFeeTakeRate() internal returns (FeeTakeRate memory feeRates) {
-        feeRates = FeeTakeRate({ relayerFeeRate: randomTakeRate(), protocolFeeRate: randomTakeRate() });
-    }
-
-    /// @dev Generate a random take rate
-    function randomTakeRate() internal returns (FixedPoint memory feeRate) {
-        // Generate a random fee between 1bp and 10bps
-        // We use a fixed point representation of `x * 2^63` as is used throughout the system
-        // and generate a random integer representation between our bounds
-        uint256 oneBpFp = 922_337_203_685_477;
-        uint256 tenBpsFp = oneBpFp * 10;
-        uint256 randRepr = randomUint(oneBpFp, tenBpsFp);
-        feeRate = FixedPoint({ repr: randRepr });
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds test helpers, structure, and valid match tests to the `processMalleableAtomicMatchSettle` method.

### Todo
- Test native asset trades
- Test non-sender receiver trades
- Test invalid cases

### Testing
- [x] Unit tests pass