### PR TITLE
test: darkpool: SettleMalleableMatch: Test native asset matches and non-sender receiver

### DIFF
--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -54,7 +54,7 @@ contract DarkpoolTestBase is CalldataUtils {
         weth = new WethMock();
 
         // Capitalize the weth contract
-        vm.deal(address(weth), 100 ether);
+        vm.deal(address(weth), 100_000_000_000_000 ether);
 
         // Deploy the darkpool implementation contracts
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));


### PR DESCRIPTION
### Purpose
This PR adds `processMalleableAtomicMatchSettle` test cases covering the following valid configurations:
- Non-sender receiver: the tokens withdrawn from the darkpool go to an address that is different from `msg.sender`
- Native asset trades: both sell and buy side trading ETH rather than WETH

### Todo
- Invalid test cases

### Testing
- [x] All unit tests pass