### PR TITLE
test: darkpool: SettleMalleableMatch: Add invalid test cases

### DIFF
--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -42,6 +42,8 @@ contract DarkpoolTestBase is CalldataUtils {
     bytes constant INVALID_PROTOCOL_FEE_KEY_REVERT_STRING = "Invalid protocol fee encryption key";
     bytes constant INVALID_ETH_VALUE_REVERT_STRING = "Invalid ETH value, should be zero unless selling native token";
     bytes constant INVALID_ETH_DEPOSIT_AMOUNT_REVERT_STRING = "msg.value does not match deposit amount";
+    bytes constant INVALID_INTERNAL_PARTY_FEE_REVERT_STRING = "Invalid internal party protocol fee rate";
+    bytes constant INVALID_EXTERNAL_PARTY_FEE_REVERT_STRING = "Invalid external party protocol fee rate";
 
     function setUp() public virtual {
         // Deploy a Permit2 instance for testing


### PR DESCRIPTION
### Purpose
This PR adds tests for invalid cases in settling a malleable atomic match, and asserts they all revert at the appropriate locations.

### Testing
- [x] All unit tests pass