### PR TITLE
test: darkpool: Add verification failure tests

### DIFF
--- a/test/darkpool/CreateWallet.t.sol
+++ b/test/darkpool/CreateWallet.t.sol
@@ -13,4 +13,11 @@ contract CreateWalletTest is DarkpoolTestBase {
         (ValidWalletCreateStatement memory statement, PlonkProof memory proof) = createWalletCalldata();
         darkpool.createWallet(statement, proof);
     }
+
+    /// @notice Test creating a wallet with an invalid proof
+    function test_createWallet_invalidProof() public {
+        (ValidWalletCreateStatement memory statement, PlonkProof memory proof) = createWalletCalldata();
+        vm.expectRevert("Verification failed for wallet create");
+        darkpoolRealVerifier.createWallet(statement, proof);
+    }
 }

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -19,12 +19,15 @@ import { NullifierLib } from "renegade-lib/darkpool/NullifierSet.sol";
 import { WalletOperations } from "renegade-lib/darkpool/WalletOperations.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "renegade-lib/interfaces/IVerifier.sol";
+import { Verifier } from "renegade/Verifier.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
 contract DarkpoolTestBase is CalldataUtils {
     using NullifierLib for NullifierLib.NullifierSet;
 
     Darkpool public darkpool;
+    /// @dev A separate instance of the darkpool contract without a verifier mock
+    Darkpool public darkpoolRealVerifier;
     IHasher public hasher;
     NullifierLib.NullifierSet private testNullifierSet;
     IPermit2 public permit2;
@@ -61,9 +64,13 @@ contract DarkpoolTestBase is CalldataUtils {
         // Deploy the darkpool implementation contracts
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
         IVerifier verifier = new TestVerifier();
+        IVerifier realVerifier = new Verifier();
         protocolFeeAddr = vm.randomAddress();
         EncryptionKey memory protocolFeeKey = randomEncryptionKey();
+
         darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, verifier, permit2);
+        darkpoolRealVerifier =
+            new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, realVerifier, permit2);
     }
 
     /// @dev Get the base and quote token amounts for an address

--- a/test/darkpool/RedeemFee.t.sol
+++ b/test/darkpool/RedeemFee.t.sol
@@ -30,6 +30,21 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
     // --- Invalid Cases --- //
 
+    /// @notice Test redeeming a fee with an invalid proof
+    function test_redeemFee_invalidProof() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        Vm.Wallet memory receiverWallet = randomEthereumWallet();
+
+        // Generate the calldata and redeem the fee
+        (bytes memory newSharesCommitmentSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
+            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
+
+        // Should fail
+        vm.expectRevert("Verification failed for fee redemption");
+        darkpoolRealVerifier.redeemFee(newSharesCommitmentSig, statement, proof);
+    }
+
     /// @notice Test redeeming a fee with an invalid wallet merkle root
     function test_redeemFee_invalidWalletMerkleRoot() public {
         // Setup calldata

--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -409,6 +409,30 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
 
     // --- Invalid Match Tests --- //
 
+    /// @notice Test settling an atomic match with an invalid proof
+    function test_settleAtomicMatch_invalidProof() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        ExternalMatchResult memory matchResult = ExternalMatchResult({
+            quoteMint: address(quoteToken),
+            baseMint: address(baseToken),
+            quoteAmount: QUOTE_AMT,
+            baseAmount: BASE_AMT,
+            direction: ExternalMatchDirection.InternalPartyBuy
+        });
+
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleAtomicMatchCalldataWithMatchResult(merkleRoot, matchResult);
+
+        // Should fail
+        vm.expectRevert("Verification failed for atomic match bundle");
+        darkpoolRealVerifier.processAtomicMatchSettle(internalPartyPayload, statement, proofs, linkingProofs);
+    }
+
     /// @notice Test settling an atomic match wherein the fees exceed the receive amount
     function test_settleAtomicMatch_feesExceedReceiveAmount() public {
         // Setup match

--- a/test/darkpool/SettleMalleableAtomicMatch.t.sol
+++ b/test/darkpool/SettleMalleableAtomicMatch.t.sol
@@ -166,6 +166,24 @@ contract SettleMalleableAtomicMatch is DarkpoolTestBase {
 
     // --- Invalid Match Test Cases --- //
 
+    /// @notice Test settling a malleable match with an invalid proof
+    function test_settleMalleableAtomicMatch_invalidProof() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = genMalleableMatchCalldata(ExternalMatchDirection.InternalPartySell, merkleRoot);
+
+        // Should fail
+        vm.expectRevert("Verification failed for malleable match bundle");
+        darkpoolRealVerifier.processMalleableAtomicMatchSettle(
+            statement.matchResult.minBaseAmount, txSender, internalPartyPayload, statement, proofs, linkingProofs
+        );
+    }
+
     /// @notice Test settling a malleable match with a spent nullifier
     function test_settleMalleableAtomicMatch_spentNullifier() public {
         // Spend the nullifier with an update wallet

--- a/test/darkpool/SettleMatch.t.sol
+++ b/test/darkpool/SettleMatch.t.sol
@@ -34,6 +34,23 @@ contract SettleMatchTest is DarkpoolTestBase {
         assertEq(darkpool.nullifierSpent(nullifier1), true);
     }
 
+    /// @notice Test settling a match with an invalid proof
+    function test_settleMatch_invalidProof() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory party0Payload,
+            PartyMatchPayload memory party1Payload,
+            ValidMatchSettleStatement memory statement,
+            MatchProofs memory proofs,
+            MatchLinkingProofs memory linkingProofs
+        ) = settleMatchCalldata(merkleRoot);
+
+        // Should fail
+        vm.expectRevert("Verification failed for match bundle");
+        darkpoolRealVerifier.processMatchSettle(party0Payload, party1Payload, statement, proofs, linkingProofs);
+    }
+
     /// @notice Test settling a match in which the nullifier of one party is spent
     function test_settleMatch_spentNullifier() public {
         BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();

--- a/test/darkpool/SettleOfflineFee.t.sol
+++ b/test/darkpool/SettleOfflineFee.t.sol
@@ -29,6 +29,19 @@ contract SettleOfflineFee is DarkpoolTestBase {
 
     // --- Invalid Test Cases --- //
 
+    /// @notice Test settling an offline fee with an invalid proof
+    function test_settleOfflineFee_invalidProof() public {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        EncryptionKey memory protocolFeeKey = darkpool.getProtocolFeeKey();
+        (ValidOfflineFeeSettlementStatement memory statement, PlonkProof memory proof) =
+            settleOfflineFeeCalldata(merkleRoot, protocolFeeKey);
+
+        // Should fail
+        vm.expectRevert("Verification failed for offline fee settlement");
+        darkpoolRealVerifier.settleOfflineFee(statement, proof);
+    }
+
     /// @notice Test settling an offline fee with an invalid Merkle root
     function test_settleOfflineFee_invalidMerkleRoot() public {
         // Get the protocol fee key and merkle root


### PR DESCRIPTION
### Purpose
This PR instantiates a separate darkpool test contract using the real verifier and asserts that verification fails for proofs of all invalid circuits.

### Todo
- Add tests with successful proofs in integration tests

### Testing
- [x] All unit tests pass