### PR TITLE
VKeys.sol, Verifier.sol: Break verification keys out into separate contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/
 !/broadcast
 /broadcast/*/31337/
 /broadcast/**/dry-run/
+broadcast
 
 # Docs
 docs/

--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
-import { PlonkProof, VerificationKey, NUM_SELECTORS, NUM_WIRE_TYPES } from "./libraries/verifier/Types.sol";
+import { PlonkProof, VerificationKey, NUM_SELECTORS, NUM_WIRE_TYPES } from "renegade-lib/verifier/Types.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { VerifierCore } from "./libraries/verifier/VerifierCore.sol";
 import { VerificationKeys } from "./libraries/darkpool/VerificationKeys.sol";

--- a/src/VKeys.sol
+++ b/src/VKeys.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { VerificationKey, ProofLinkingVK } from "./libraries/verifier/Types.sol";
+import { VerificationKeys } from "./libraries/darkpool/VerificationKeys.sol";
+import { IVKeys } from "./libraries/interfaces/IVKeys.sol";
+
+contract VKeys is IVKeys {
+    // Individual verification keys
+    function walletCreateKeys() external pure override returns (VerificationKey memory) {
+        return deserializeKey(VerificationKeys.VALID_WALLET_CREATE_VKEY);
+    }
+
+    function walletUpdateKeys() external pure override returns (VerificationKey memory) {
+        return deserializeKey(VerificationKeys.VALID_WALLET_UPDATE_VKEY);
+    }
+
+    function offlineFeeSettlementKeys() external pure override returns (VerificationKey memory) {
+        return deserializeKey(VerificationKeys.VALID_OFFLINE_FEE_SETTLEMENT_VKEY);
+    }
+
+    function feeRedemptionKeys() external pure override returns (VerificationKey memory) {
+        return deserializeKey(VerificationKeys.VALID_FEE_REDEMPTION_VKEY);
+    }
+
+    // Match bundle keys
+    function matchBundleKeys()
+        external
+        pure
+        override
+        returns (
+            VerificationKey memory commitmentsVk,
+            VerificationKey memory reblindVk,
+            VerificationKey memory settleVk,
+            ProofLinkingVK memory reblindCommitmentsVk,
+            ProofLinkingVK memory commitmentsMatchSettleVk0,
+            ProofLinkingVK memory commitmentsMatchSettleVk1
+        )
+    {
+        commitmentsVk = deserializeKey(VerificationKeys.VALID_COMMITMENTS_VKEY);
+        reblindVk = deserializeKey(VerificationKeys.VALID_REBLIND_VKEY);
+        settleVk = deserializeKey(VerificationKeys.VALID_MATCH_SETTLE_VKEY);
+        reblindCommitmentsVk = deserializeLinkKey(VerificationKeys.VALID_REBLIND_COMMITMENTS_LINK_VKEY);
+        commitmentsMatchSettleVk0 = deserializeLinkKey(VerificationKeys.VALID_COMMITMENTS_MATCH_SETTLE_LINK0_VKEY);
+        commitmentsMatchSettleVk1 = deserializeLinkKey(VerificationKeys.VALID_COMMITMENTS_MATCH_SETTLE_LINK1_VKEY);
+    }
+
+    // Atomic match bundle keys
+    function atomicMatchBundleKeys()
+        external
+        pure
+        override
+        returns (
+            VerificationKey memory commitmentsVk,
+            VerificationKey memory reblindVk,
+            VerificationKey memory settleVk,
+            ProofLinkingVK memory reblindCommitmentsVk,
+            ProofLinkingVK memory commitmentsMatchSettleVk
+        )
+    {
+        commitmentsVk = deserializeKey(VerificationKeys.VALID_COMMITMENTS_VKEY);
+        reblindVk = deserializeKey(VerificationKeys.VALID_REBLIND_VKEY);
+        settleVk = deserializeKey(VerificationKeys.VALID_MATCH_SETTLE_ATOMIC_VKEY);
+        reblindCommitmentsVk = deserializeLinkKey(VerificationKeys.VALID_REBLIND_COMMITMENTS_LINK_VKEY);
+        commitmentsMatchSettleVk = deserializeLinkKey(VerificationKeys.VALID_COMMITMENTS_MATCH_SETTLE_LINK0_VKEY);
+    }
+
+    // Malleable match bundle keys
+    function malleableMatchBundleKeys()
+        external
+        pure
+        override
+        returns (
+            VerificationKey memory commitmentsVk,
+            VerificationKey memory reblindVk,
+            VerificationKey memory settleVk,
+            ProofLinkingVK memory reblindCommitmentsVk,
+            ProofLinkingVK memory commitmentsMatchSettleVk
+        )
+    {
+        commitmentsVk = deserializeKey(VerificationKeys.VALID_COMMITMENTS_VKEY);
+        reblindVk = deserializeKey(VerificationKeys.VALID_REBLIND_VKEY);
+        settleVk = deserializeKey(VerificationKeys.VALID_MALLEABLE_MATCH_SETTLE_ATOMIC_VKEY);
+        reblindCommitmentsVk = deserializeLinkKey(VerificationKeys.VALID_REBLIND_COMMITMENTS_LINK_VKEY);
+        commitmentsMatchSettleVk = deserializeLinkKey(VerificationKeys.VALID_COMMITMENTS_MATCH_SETTLE_LINK0_VKEY);
+    }
+
+    // Helper functions for deserialization
+    function deserializeKey(bytes memory vkeyBytes) internal pure returns (VerificationKey memory vk) {
+        return abi.decode(vkeyBytes, (VerificationKey));
+    }
+
+    function deserializeLinkKey(bytes memory vkeyBytes) internal pure returns (ProofLinkingVK memory vk) {
+        return abi.decode(vkeyBytes, (ProofLinkingVK));
+    }
+}

--- a/src/libraries/interfaces/IVKeys.sol
+++ b/src/libraries/interfaces/IVKeys.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { VerificationKey, ProofLinkingVK } from "renegade-lib/verifier/Types.sol";
+
+interface IVKeys {
+    // Individual verification keys
+    /// @notice Get the verification key for `VALID WALLET CREATE`
+    function walletCreateKeys() external view returns (VerificationKey memory);
+
+    /// @notice Get the verification key for `VALID WALLET UPDATE`
+    function walletUpdateKeys() external view returns (VerificationKey memory);
+
+    /// @notice Get the verification key for `VALID OFFLINE FEE SETTLEMENT`
+    function offlineFeeSettlementKeys() external view returns (VerificationKey memory);
+
+    /// @notice Get the verification key for `VALID FEE REDEMPTION`
+    function feeRedemptionKeys() external view returns (VerificationKey memory);
+
+    // Match bundle keys
+    /// @notice Get all verification keys needed for a match bundle verification
+    /// @return commitmentsVk The verification key for `VALID COMMITMENTS`
+    /// @return reblindVk The verification key for `VALID REBLIND`
+    /// @return settleVk The verification key for `VALID MATCH SETTLE`
+    /// @return reblindCommitmentsVk The linking key for `VALID REBLIND` -> `VALID COMMITMENTS`
+    /// @return commitmentsMatchSettleVk0 The linking key for party 0's `VALID COMMITMENTS` -> `VALID MATCH SETTLE`
+    /// @return commitmentsMatchSettleVk1 The linking key for party 1's `VALID COMMITMENTS` -> `VALID MATCH SETTLE`
+    function matchBundleKeys()
+        external
+        view
+        returns (
+            VerificationKey memory commitmentsVk,
+            VerificationKey memory reblindVk,
+            VerificationKey memory settleVk,
+            ProofLinkingVK memory reblindCommitmentsVk,
+            ProofLinkingVK memory commitmentsMatchSettleVk0,
+            ProofLinkingVK memory commitmentsMatchSettleVk1
+        );
+
+    // Atomic match bundle keys
+    /// @notice Get all verification keys needed for an atomic match bundle verification
+    /// @return commitmentsVk The verification key for `VALID COMMITMENTS`
+    /// @return reblindVk The verification key for `VALID REBLIND`
+    /// @return settleVk The verification key for `VALID MATCH SETTLE ATOMIC`
+    /// @return reblindCommitmentsVk The linking key for `VALID REBLIND` -> `VALID COMMITMENTS`
+    /// @return commitmentsMatchSettleVk The linking key for `VALID COMMITMENTS` -> `VALID MATCH SETTLE ATOMIC`
+    function atomicMatchBundleKeys()
+        external
+        view
+        returns (
+            VerificationKey memory commitmentsVk,
+            VerificationKey memory reblindVk,
+            VerificationKey memory settleVk,
+            ProofLinkingVK memory reblindCommitmentsVk,
+            ProofLinkingVK memory commitmentsMatchSettleVk
+        );
+
+    // Malleable match bundle keys
+    /// @notice Get all verification keys needed for a malleable match bundle verification
+    /// @return commitmentsVk The verification key for `VALID COMMITMENTS`
+    /// @return reblindVk The verification key for `VALID REBLIND`
+    /// @return settleVk The verification key for `VALID MALLEABLE MATCH SETTLE ATOMIC`
+    /// @return reblindCommitmentsVk The linking key for `VALID REBLIND` -> `VALID COMMITMENTS`
+    /// @return commitmentsMatchSettleVk The linking key for `VALID COMMITMENTS` -> `VALID MALLEABLE MATCH SETTLE
+    /// ATOMIC`
+    function malleableMatchBundleKeys()
+        external
+        view
+        returns (
+            VerificationKey memory commitmentsVk,
+            VerificationKey memory reblindVk,
+            VerificationKey memory settleVk,
+            ProofLinkingVK memory reblindCommitmentsVk,
+            ProofLinkingVK memory commitmentsMatchSettleVk
+        );
+}

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -21,6 +21,8 @@ import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "renegade-lib/interfaces/IVerifier.sol";
 import { Verifier } from "renegade/Verifier.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
+import { VKeys } from "renegade/VKeys.sol";
+import { IVKeys } from "renegade/libraries/interfaces/IVKeys.sol";
 
 contract DarkpoolTestBase is CalldataUtils {
     using NullifierLib for NullifierLib.NullifierSet;
@@ -34,6 +36,7 @@ contract DarkpoolTestBase is CalldataUtils {
     ERC20Mock public quoteToken;
     ERC20Mock public baseToken;
     WethMock public weth;
+    IVKeys public vkeys;
 
     address public protocolFeeAddr;
 
@@ -63,8 +66,9 @@ contract DarkpoolTestBase is CalldataUtils {
 
         // Deploy the darkpool implementation contracts
         hasher = IHasher(HuffDeployer.deploy("libraries/poseidon2/poseidonHasher"));
-        IVerifier verifier = new TestVerifier();
-        IVerifier realVerifier = new Verifier();
+        vkeys = new VKeys();
+        IVerifier verifier = new TestVerifier(vkeys);
+        IVerifier realVerifier = new Verifier(vkeys);
         protocolFeeAddr = vm.randomAddress();
         EncryptionKey memory protocolFeeKey = randomEncryptionKey();
 

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -19,7 +19,7 @@ import {
     MatchAtomicLinkingProofs,
     MalleableMatchAtomicProofs
 } from "renegade-lib/darkpool/types/Settlement.sol";
-import { VerificationKeys } from "renegade-lib/darkpool/VerificationKeys.sol";
+import { IVKeys } from "renegade/libraries/interfaces/IVKeys.sol";
 import { IVerifier } from "renegade-lib/interfaces/IVerifier.sol";
 import { Verifier } from "renegade/Verifier.sol";
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
@@ -31,8 +31,8 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 contract TestVerifier is IVerifier {
     Verifier private verifier;
 
-    constructor() {
-        verifier = new Verifier();
+    constructor(IVKeys _vkeys) {
+        verifier = new Verifier(_vkeys);
     }
 
     /// @notice Verify a proof of `VALID WALLET CREATE`


### PR DESCRIPTION
### Purpose
This PR separates out the verification keys into a separate contract used by the verifier. This brings the verifier under the 24KB runtime code size.

### Testing
- [x] All tests pass