### PR TITLE
script: Deploy hasher via huffc directly

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -20,6 +20,6 @@ contract DeployScript is Script {
 
     function run(address permit2Address, address wethAddress, address protocolFeeAddr) public {
         // Call the shared deployment logic
-        DeployUtils.deployCore(permit2Address, wethAddress, protocolFeeAddr);
+        DeployUtils.deployCore(permit2Address, wethAddress, protocolFeeAddr, vm);
     }
 }

--- a/script/DeployDev.s.sol
+++ b/script/DeployDev.s.sol
@@ -24,11 +24,7 @@ contract DeployDevScript is Script {
         console.log("WETH Mock deployed at:", address(weth));
 
         // Call the shared deployment logic
-
-        // Deploy Hasher
-        IHasher hasher = IHasher(HuffDeployer.broadcast("src/libraries/poseidon2/poseidonHasher"));
-        console.log("Hasher deployed at:", address(hasher));
-        // DeployUtils.deployCore(permit2, address(weth), address(0x42));
+        DeployUtils.deployCore(permit2, address(weth), address(0x42), vm);
         vm.stopBroadcast();
     }
 }

--- a/src/libraries/poseidon2/poseidonSponge.huff
+++ b/src/libraries/poseidon2/poseidonSponge.huff
@@ -31,7 +31,7 @@
 }
 
 /// @dev Absorb two inputs into the state, adding them to the existing state without permutation
-#define macro ABSORB_NEXT_TWO() = takes(5) returns(5) {
+#define fn ABSORB_NEXT_TWO() = takes(5) returns(5) {
     // Takes    [state[0], state[1], state[2], len(inputs), *nextElem]
     // Returns  [state'[0], state'[1], state'[2], len(inputs) - 2, *nextElem + 64]
 


### PR DESCRIPTION
### Purpose
This PR changes the deploy scripts to use `huffc` directly rather than the huff foundry deploy utils. These utils use a prank to deploy the contract rather than inheriting the active broadcast if one exists, so they are not usable in a real deploy script.

### Todo
- Setup CLI args for the encryption key, fee address, etc
- Write integration tests with these scripts

### Testing
- [x] All unit tests pass
- [x] Deploy scripts run correctly