### PR TITLE
integration: test: create-wallet: Add create wallet tests

### DIFF
--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -4,7 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# === Cryptography Dependencies === #
+ark-ff = "0.4"
+ark-ec = "0.4"
+ark-bn254 = "0.4"
+jf-primitives = { git = "https://github.com/renegade-fi/mpc-jellyfish.git" }
+
 # === Renegade Dependencies === #
+renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade", features = [
+    "test_helpers",
+] }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade" }
 test-helpers = { git = "https://github.com/renegade-fi/renegade" }
 
 # === Alloy Dependencies === #
@@ -19,3 +30,7 @@ colored = "3"
 eyre = "0.6"
 inventory = "0.3"
 tokio = { version = "1.36", features = ["full"] }
+
+# === Misc Dependencies === #
+itertools = "0.11"
+rand = "0.8"

--- a/integration/src/contracts/darkpool.rs
+++ b/integration/src/contracts/darkpool.rs
@@ -9,3 +9,4 @@ sol! {
     IDarkpool,
     "src/contracts/abis/IDarkpool.json"
 }
+pub use IDarkpool::*;

--- a/integration/src/contracts/mod.rs
+++ b/integration/src/contracts/mod.rs
@@ -1,3 +1,4 @@
 //! Solidity types for Renegade contracts
 
 pub mod darkpool;
+pub mod type_conversion;

--- a/integration/src/contracts/type_conversion.rs
+++ b/integration/src/contracts/type_conversion.rs
@@ -1,0 +1,125 @@
+//! Utilities for converting between relayer types and contract types
+
+use alloy::primitives::U256;
+use ark_ec::AffineRepr;
+use ark_ff::{BigInteger, PrimeField};
+use jf_primitives::pcs::prelude::Commitment as JfCommitment;
+use renegade_circuit_types::{traits::BaseType, PlonkProof};
+use renegade_circuits::zk_circuits::valid_wallet_create::SizedValidWalletCreateStatement;
+use renegade_constants::Scalar;
+
+use super::darkpool::{
+    PlonkProof as ContractPlonkProof,
+    ValidWalletCreateStatement as ContractValidWalletCreateStatement,
+    BN254::G1Point as ContractG1Point,
+};
+
+// -------------------
+// | Statement Types |
+// -------------------
+
+/// Convert a relayer [`SizedValidWalletCreateStatement`] to a contract [`ValidWalletCreateStatement`]
+impl From<SizedValidWalletCreateStatement> for ContractValidWalletCreateStatement {
+    fn from(statement: SizedValidWalletCreateStatement) -> Self {
+        Self {
+            privateShareCommitment: scalar_to_u256(statement.private_shares_commitment),
+            publicShares: statement
+                .public_wallet_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+        }
+    }
+}
+
+// ----------------------
+// | Proof System Types |
+// ----------------------
+
+/// Convert from a relayer's `PlonkProof` to a contract's `Proof`
+impl From<PlonkProof> for ContractPlonkProof {
+    fn from(proof: PlonkProof) -> Self {
+        let evals = proof.poly_evals;
+        Self {
+            wire_comms: size_vec(
+                proof
+                    .wires_poly_comms
+                    .into_iter()
+                    .map(convert_jf_commitment)
+                    .collect(),
+            ),
+            z_comm: convert_jf_commitment(proof.prod_perm_poly_comm),
+            quotient_comms: size_vec(
+                proof
+                    .split_quot_poly_comms
+                    .into_iter()
+                    .map(convert_jf_commitment)
+                    .collect(),
+            ),
+            w_zeta: convert_jf_commitment(proof.opening_proof),
+            w_zeta_omega: convert_jf_commitment(proof.shifted_opening_proof),
+            wire_evals: size_vec(evals.wires_evals.into_iter().map(fr_to_u256).collect()),
+            sigma_evals: size_vec(evals.wire_sigma_evals.into_iter().map(fr_to_u256).collect()),
+            z_bar: fr_to_u256(evals.perm_next_eval),
+        }
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Size a vector of values to be a known fixed size
+fn size_vec<const N: usize, T>(vec: Vec<T>) -> [T; N] {
+    vec.try_into()
+        .unwrap_or_else(|_| panic!("vector is not the correct size"))
+}
+
+// --- Scalars --- //
+
+/// Convert a Scalar to a Uint256
+fn scalar_to_u256(scalar: Scalar) -> U256 {
+    let bytes = scalar.to_bytes_be();
+    bytes_to_u256(&bytes)
+}
+
+/// Convert a `Fr` to a `U256`
+///
+/// This is the same field as `Scalar`, but must first be wrapped
+fn fr_to_u256(fr: ark_bn254::Fr) -> U256 {
+    scalar_to_u256(Scalar::new(fr))
+}
+
+/// Convert a point in the BN254 base field to a Uint256
+fn base_field_to_u256(fq: ark_bn254::Fq) -> U256 {
+    let bytes = fq.into_bigint().to_bytes_be();
+    bytes_to_u256(&bytes)
+}
+
+/// Convert a set of big endian bytes to a Uint256
+///
+/// Handles padding as necessary
+fn bytes_to_u256(bytes: &[u8]) -> U256 {
+    let mut buf = [0u8; 32];
+    buf[..bytes.len()].copy_from_slice(bytes);
+    U256::from_be_bytes(buf)
+}
+
+// --- Curve Points --- //
+
+/// Convert a point on the BN254 curve to a `G1Point` in the contract's format
+fn convert_g1_point(point: ark_bn254::G1Affine) -> ContractG1Point {
+    let x = point.x().expect("x is zero");
+    let y = point.y().expect("y is zero");
+
+    ContractG1Point {
+        x: base_field_to_u256(*x),
+        y: base_field_to_u256(*y),
+    }
+}
+
+/// Convert a `JfCommitment` to a `G1Point`
+fn convert_jf_commitment(commitment: JfCommitment<ark_bn254::Bn254>) -> ContractG1Point {
+    convert_g1_point(commitment.0)
+}

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -8,6 +8,7 @@
 
 mod contracts;
 mod tests;
+mod util;
 
 use std::str::FromStr;
 

--- a/integration/src/tests/create_wallet.rs
+++ b/integration/src/tests/create_wallet.rs
@@ -1,0 +1,94 @@
+//! Tests for creating a wallet
+
+use eyre::Result;
+use itertools::Itertools;
+use rand::thread_rng;
+use renegade_circuit_types::{
+    elgamal::DecryptionKey, fixed_point::FixedPoint,
+    native_helpers::compute_wallet_private_share_commitment, SizedWallet,
+};
+use renegade_circuits::{
+    singleprover_prove,
+    zk_circuits::{
+        test_helpers::{create_wallet_shares_with_blinder_seed, PUBLIC_KEYS},
+        valid_wallet_create::{
+            SizedValidWalletCreate, SizedValidWalletCreateStatement, SizedValidWalletCreateWitness,
+        },
+    },
+};
+use renegade_constants::Scalar;
+use test_helpers::integration_test_async;
+
+use crate::{util::wait_for_tx_success, TestArgs};
+
+// ---------
+// | Tests |
+// ---------
+
+/// Test creating a wallet
+async fn test_create_wallet(args: TestArgs) -> Result<()> {
+    let darkpool = args.darkpool.clone();
+
+    // Create a proof of `VALID WALLET CREATE`
+    let (witness, statement) = create_sized_witness_statement();
+    let proof = singleprover_prove::<SizedValidWalletCreate>(witness, statement.clone())?;
+
+    let contract_statement = statement.into();
+    let contract_proof = proof.into();
+    let pending_tx = darkpool.createWallet(contract_statement, contract_proof);
+
+    // Wait for the transaction receipt and ensure it was successful
+    wait_for_tx_success(pending_tx).await
+}
+integration_test_async!(test_create_wallet);
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Create a `VALID WALLET CREATE` statement and witness
+pub fn create_sized_witness_statement() -> (
+    SizedValidWalletCreateWitness,
+    SizedValidWalletCreateStatement,
+) {
+    // Create an empty wallet
+    let mut rng = thread_rng();
+    let (_, enc) = DecryptionKey::random_pair(&mut rng);
+    let mut wallet = SizedWallet {
+        balances: create_default_arr(),
+        orders: create_default_arr(),
+        keys: PUBLIC_KEYS.clone(),
+        max_match_fee: FixedPoint::from_f64_round_down(0.0001),
+        managing_cluster: enc,
+        blinder: Scalar::zero(),
+    };
+
+    let blinder_seed = Scalar::random(&mut rng);
+    let (private_shares, public_shares) =
+        create_wallet_shares_with_blinder_seed(&mut wallet, blinder_seed);
+    let private_shares_commitment = compute_wallet_private_share_commitment(&private_shares);
+
+    (
+        SizedValidWalletCreateWitness {
+            private_wallet_share: private_shares,
+            blinder_seed,
+        },
+        SizedValidWalletCreateStatement {
+            private_shares_commitment,
+            public_wallet_shares: public_shares,
+        },
+    )
+}
+
+/// Create an array of default values
+pub fn create_default_arr<const N: usize, D: Default>() -> [D; N]
+where
+    [D; N]: Sized,
+{
+    (0..N)
+        .map(|_| D::default())
+        .collect_vec()
+        .try_into()
+        .map_err(|_| "Failed to create default array")
+        .unwrap()
+}

--- a/integration/src/tests/mod.rs
+++ b/integration/src/tests/mod.rs
@@ -1,3 +1,4 @@
 //! Module containing the actual integration tests
 
 mod basic;
+mod create_wallet;

--- a/integration/src/util.rs
+++ b/integration/src/util.rs
@@ -1,0 +1,22 @@
+//! Utilities for integration tests
+
+use alloy::{network::Ethereum, providers::DynProvider, rpc::types::TransactionReceipt};
+use alloy_contract::{CallBuilder, CallDecoder};
+use eyre::Result;
+use test_helpers::assert_eq_result;
+
+/// The call builder type for the tests
+pub type TestCallBuilder<'a, C> = CallBuilder<(), &'a DynProvider, C, Ethereum>;
+
+/// Wait for a transaction receipt and ensure it was successful
+pub async fn wait_for_tx_success<C: CallDecoder>(tx: TestCallBuilder<'_, C>) -> Result<()> {
+    let receipt = send_tx(tx).await?;
+    assert_eq_result!(receipt.status(), true)
+}
+
+/// Send a transaction and wait for it to succeed or fail
+pub async fn send_tx<C: CallDecoder>(tx: TestCallBuilder<'_, C>) -> Result<TransactionReceipt> {
+    let pending_tx = tx.send().await?;
+    let receipt = pending_tx.get_receipt().await?;
+    Ok(receipt)
+}


### PR DESCRIPTION
### Purpose
This PR adds a basic validity test for `createWallet` that submits a valid proof of `VALID WALLET CREATE` to the contract. This PR also contains a number of helpers for structuring calldata and watching transactions.

### Todo
- Test share recovery from a wallet create method

### Testing
- [x] Unit tests pass
- [x] Integration tests pass