### PR TITLE
Darkpool, libraries: merkle: MerkleTree: emit Merkle opening and wallet update events

### DIFF
--- a/integration/src/tests/create_wallet.rs
+++ b/integration/src/tests/create_wallet.rs
@@ -35,10 +35,10 @@ async fn test_create_wallet(args: TestArgs) -> Result<()> {
 
     let contract_statement = statement.into();
     let contract_proof = proof.into();
-    let pending_tx = darkpool.createWallet(contract_statement, contract_proof);
+    let tx = darkpool.createWallet(contract_statement, contract_proof);
 
     // Wait for the transaction receipt and ensure it was successful
-    wait_for_tx_success(pending_tx).await
+    wait_for_tx_success(tx).await
 }
 integration_test_async!(test_create_wallet);
 

--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -86,6 +86,10 @@ contract Darkpool {
     /// @dev This ensures that a pre-update wallet cannot create two separate post-update wallets in the Merkle state
     /// @dev The nullifier is computed deterministically from the shares of the pre-update wallet
     NullifierLib.NullifierSet private nullifierSet;
+    /// @notice The set of public blinder shares that have been inserted into the darkpool
+    /// @dev We track this to prevent duplicate blinders that may affect the ability of indexers to uniquely
+    /// @dev recover a wallet
+    NullifierLib.NullifierSet private publicBlinderSet;
 
     /// @notice The constructor for the darkpool
     /// @param hasher_ The hasher for the darkpool
@@ -174,7 +178,7 @@ contract Darkpool {
 
         // 2. Insert the wallet shares into the Merkle tree
         WalletOperations.insertWalletCommitment(
-            statement.privateShareCommitment, statement.publicShares, merkleTree, hasher
+            statement.privateShareCommitment, statement.publicShares, merkleTree, publicBlinderSet, hasher
         );
     }
 
@@ -202,6 +206,7 @@ contract Darkpool {
             statement.newPrivateShareCommitment,
             statement.newPublicShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );
@@ -263,6 +268,7 @@ contract Darkpool {
             reblindStatement0.newPrivateShareCommitment,
             matchSettleStatement.firstPartyPublicShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );
@@ -272,6 +278,7 @@ contract Darkpool {
             reblindStatement1.newPrivateShareCommitment,
             matchSettleStatement.secondPartyPublicShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );
@@ -356,6 +363,7 @@ contract Darkpool {
             reblindStatement.newPrivateShareCommitment,
             matchSettleStatement.internalPartyModifiedShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );
@@ -437,6 +445,7 @@ contract Darkpool {
             reblindStatement.newPrivateShareCommitment,
             newShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );
@@ -474,6 +483,7 @@ contract Darkpool {
             statement.updatedWalletCommitment,
             statement.updatedWalletPublicShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );
@@ -503,6 +513,7 @@ contract Darkpool {
             statement.newWalletCommitment,
             statement.newWalletPublicShares,
             nullifierSet,
+            publicBlinderSet,
             merkleTree,
             hasher
         );

--- a/src/libraries/darkpool/NullifierSet.sol
+++ b/src/libraries/darkpool/NullifierSet.sol
@@ -25,7 +25,7 @@ library NullifierLib {
     /// @notice Mark a nullifier as spent
     /// @param nullifier The nullifier to spend
     function spend(NullifierSet storage self, BN254.ScalarField nullifier) public {
-        require(!isSpent(self, nullifier), "Nullifier already spent");
+        require(!isSpent(self, nullifier), "nullifier/blinder already spent");
         uint256 nullifierUint = BN254.ScalarField.unwrap(nullifier);
         self.nullifiers[nullifierUint] = true;
     }

--- a/src/libraries/interfaces/IDarkpool.sol
+++ b/src/libraries/interfaces/IDarkpool.sol
@@ -34,6 +34,21 @@ import { FeeTake } from "renegade-lib/darkpool/types/Fees.sol";
 import { EncryptionKey } from "renegade-lib/darkpool/types/Ciphertext.sol";
 
 interface IDarkpool {
+    // --- Events --- //
+
+    /// @notice Emitted when a wallet update is performed
+    /// @param wallet_blinder_share The public blinder share of the wallet, used for indexing
+    event WalletUpdated(uint256 indexed wallet_blinder_share);
+    /// @notice Emitted when an internal Merkle node is updated
+    /// @param depth The depth at which the node is updated
+    /// @param index The index of the node in the Merkle tree
+    /// @param new_value The new value of the node
+    event MerkleOpeningNode(uint8 indexed depth, uint128 indexed index, uint256 indexed new_value);
+    /// @notice Emitted when a Merkle leaf is inserted into the tree
+    /// @param index The leaf index
+    /// @param value The value of the leaf
+    event MerkleInsertion(uint128 indexed index, uint256 indexed value);
+
     // --- State Getters --- //
 
     /// @notice Get the current Merkle root

--- a/test/darkpool/CreateWallet.t.sol
+++ b/test/darkpool/CreateWallet.t.sol
@@ -14,10 +14,20 @@ contract CreateWalletTest is DarkpoolTestBase {
         darkpool.createWallet(statement, proof);
     }
 
+    // --- Invalid Cases --- //
+
     /// @notice Test creating a wallet with an invalid proof
     function test_createWallet_invalidProof() public {
         (ValidWalletCreateStatement memory statement, PlonkProof memory proof) = createWalletCalldata();
         vm.expectRevert("Verification failed for wallet create");
         darkpoolRealVerifier.createWallet(statement, proof);
+    }
+
+    /// @notice Test creating a wallet with a duplicate public blinder share
+    function test_createWallet_duplicateBlinder() public {
+        (ValidWalletCreateStatement memory statement, PlonkProof memory proof) = createWalletCalldata();
+        darkpool.createWallet(statement, proof);
+        vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
+        darkpool.createWallet(statement, proof);
     }
 }

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -40,7 +40,7 @@ contract DarkpoolTestBase is CalldataUtils {
 
     address public protocolFeeAddr;
 
-    bytes constant INVALID_NULLIFIER_REVERT_STRING = "Nullifier already spent";
+    bytes constant INVALID_NULLIFIER_REVERT_STRING = "nullifier/blinder already spent";
     bytes constant INVALID_ROOT_REVERT_STRING = "Merkle root not in history";
     bytes constant INVALID_NOTE_ROOT_REVERT_STRING = "Note not in Merkle history";
     bytes constant INVALID_SIGNATURE_REVERT_STRING = "Invalid signature";
@@ -108,7 +108,7 @@ contract DarkpoolTestBase is CalldataUtils {
         assertEq(testNullifierSet.isSpent(nullifier), true);
 
         // Should fail
-        vm.expectRevert("Nullifier already spent");
+        vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
         testNullifierSet.spend(nullifier);
     }
 }


### PR DESCRIPTION
### Purpose
This PR emits events for relayer indexing from the contract, these are:
- Merkle leaf insertion events
- Sibling path events when internal nodes are updated
- Events indicating that a public blinder has been used

I also added the public blinder set to this pr, which prevents duplicate public blinders.

### Testing
- [x] All unit tests pass
- [x] Added tests for duplicate blinders for all methods