### PR TITLE
integration: test: update-wallet: Add basic place/cancel order tests

### DIFF
--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -16,7 +16,7 @@ renegade-circuits = { package = "circuits", git = "https://github.com/renegade-f
 ] }
 renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade" }
 renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade", default-features = false, features = [
-    "wallet",
+    "all-types",
 ] }
 renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade" }
 test-helpers = { git = "https://github.com/renegade-fi/renegade" }
@@ -26,6 +26,7 @@ alloy = { version = "0.12", features = ["essentials"] }
 alloy-contract = "0.12.3"
 alloy-sol-types = "0.8.23"
 alloy-sol-macro = "0.8.23"
+ethers-signers = "2.0"
 
 # === Test Harness Dependencies === #
 clap = { version = "4.0", features = ["derive"] }

--- a/integration/src/contracts/type_conversion.rs
+++ b/integration/src/contracts/type_conversion.rs
@@ -72,8 +72,11 @@ impl From<PlonkProof> for ContractPlonkProof {
 
 /// Size a vector of values to be a known fixed size
 pub fn size_vec<const N: usize, T>(vec: Vec<T>) -> [T; N] {
-    vec.try_into()
-        .unwrap_or_else(|_| panic!("vector is not the correct size"))
+    let size = vec.len();
+    if size != N {
+        panic!("vector is not the correct size: expected {N}, got {size}");
+    }
+    vec.try_into().map_err(|_| ()).unwrap()
 }
 
 // --- Scalars --- //

--- a/integration/src/contracts/type_conversion.rs
+++ b/integration/src/contracts/type_conversion.rs
@@ -1,16 +1,25 @@
 //! Utilities for converting between relayer types and contract types
 
-use alloy::primitives::U256;
+use alloy::primitives::{Address, U256};
 use ark_ec::AffineRepr;
 use ark_ff::{BigInteger, PrimeField};
 use jf_primitives::pcs::prelude::Commitment as JfCommitment;
-use renegade_circuit_types::{traits::BaseType, PlonkProof};
+use num_bigint::BigUint;
+use renegade_circuit_types::{
+    keychain::PublicSigningKey,
+    traits::BaseType,
+    transfers::{ExternalTransfer, ExternalTransferDirection},
+    PlonkProof,
+};
 use renegade_circuits::zk_circuits::valid_wallet_create::SizedValidWalletCreateStatement;
+use renegade_circuits::zk_circuits::valid_wallet_update::SizedValidWalletUpdateStatement;
 use renegade_constants::Scalar;
 
 use super::darkpool::{
-    PlonkProof as ContractPlonkProof,
+    ExternalTransfer as ContractTransfer, PlonkProof as ContractPlonkProof,
+    PublicRootKey as ContractRootKey,
     ValidWalletCreateStatement as ContractValidWalletCreateStatement,
+    ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
     BN254::G1Point as ContractG1Point,
 };
 
@@ -30,6 +39,58 @@ impl From<SizedValidWalletCreateStatement> for ContractValidWalletCreateStatemen
                 .map(scalar_to_u256)
                 .collect(),
         }
+    }
+}
+
+/// Convert a relayer [`SizedValidWalletUpdateStatement`] to a contract [`ValidWalletUpdateStatement`]
+impl From<SizedValidWalletUpdateStatement> for ContractValidWalletUpdateStatement {
+    fn from(statement: SizedValidWalletUpdateStatement) -> Self {
+        Self {
+            previousNullifier: scalar_to_u256(statement.old_shares_nullifier),
+            newPrivateShareCommitment: scalar_to_u256(statement.new_private_shares_commitment),
+            newPublicShares: statement
+                .new_public_shares
+                .to_scalars()
+                .into_iter()
+                .map(scalar_to_u256)
+                .collect(),
+            merkleRoot: scalar_to_u256(statement.merkle_root),
+            externalTransfer: statement.external_transfer.into(),
+            oldPkRoot: statement.old_pk_root.into(),
+        }
+    }
+}
+
+// ---------------------
+// | Application Types |
+// ---------------------
+
+/// Convert a relayer [`ExternalTransfer`] to a contract [`ExternalTransfer`]
+impl From<ExternalTransfer> for ContractTransfer {
+    fn from(transfer: ExternalTransfer) -> Self {
+        let transfer_type = match transfer.direction {
+            ExternalTransferDirection::Deposit => 0,
+            ExternalTransferDirection::Withdrawal => 1,
+        };
+
+        ContractTransfer {
+            account: biguint_to_address(transfer.account_addr),
+            mint: biguint_to_address(transfer.mint),
+            amount: U256::from(transfer.amount),
+            transferType: transfer_type,
+        }
+    }
+}
+
+/// Convert a relayer [`PublicSigningKey`] to a contract [`PublicRootKey`]
+impl From<PublicSigningKey> for ContractRootKey {
+    fn from(key: PublicSigningKey) -> Self {
+        let x_words = &key.x.scalar_words;
+        let y_words = &key.y.scalar_words;
+        let x = [scalar_to_u256(x_words[0]), scalar_to_u256(x_words[1])];
+        let y = [scalar_to_u256(y_words[0]), scalar_to_u256(y_words[1])];
+
+        ContractRootKey { x, y }
     }
 }
 
@@ -79,6 +140,16 @@ pub fn size_vec<const N: usize, T>(vec: Vec<T>) -> [T; N] {
     vec.try_into().map_err(|_| ()).unwrap()
 }
 
+// --- Alloy Types --- //
+
+/// Convert a `BigUint` to a `Address`
+#[allow(clippy::needless_pass_by_value)]
+fn biguint_to_address(biguint: BigUint) -> Address {
+    let bytes = biguint.to_bytes_be();
+    let padded = pad_bytes::<20>(&bytes);
+    Address::from_slice(&padded)
+}
+
 // --- Scalars --- //
 
 /// Convert a Scalar to a Uint256
@@ -113,6 +184,15 @@ fn bytes_to_u256(bytes: &[u8]) -> U256 {
     let mut buf = [0u8; 32];
     buf[..bytes.len()].copy_from_slice(bytes);
     U256::from_be_bytes(buf)
+}
+
+/// Pad big endian bytes to a fixed size
+fn pad_bytes<const N: usize>(bytes: &[u8]) -> [u8; N] {
+    assert!(bytes.len() <= N, "bytes are too long for padding");
+
+    let mut padded = [0u8; N];
+    padded[N - bytes.len()..].copy_from_slice(bytes);
+    padded
 }
 
 // --- Curve Points --- //

--- a/integration/src/tests/mod.rs
+++ b/integration/src/tests/mod.rs
@@ -1,3 +1,4 @@
 //! Module containing the actual integration tests
 
 mod create_wallet;
+mod update_wallet;

--- a/integration/src/tests/update_wallet.rs
+++ b/integration/src/tests/update_wallet.rs
@@ -1,15 +1,183 @@
 //! Wallet update tests
 
+use alloy::primitives::{Bytes, U256};
+use eyre::Result;
+use num_bigint::BigUint;
+use renegade_circuit_types::{
+    fixed_point::FixedPoint,
+    order::OrderSide,
+    transfers::{ExternalTransfer, ExternalTransferDirection},
+    PlonkProof,
+};
+use renegade_circuits::{
+    singleprover_prove,
+    zk_circuits::valid_wallet_update::{
+        SizedValidWalletUpdate, SizedValidWalletUpdateStatement, SizedValidWalletUpdateWitness,
+    },
+};
+use renegade_common::types::wallet::{Order, OrderIdentifier, Wallet};
 use test_helpers::integration_test_async;
 
-use crate::TestArgs;
+use crate::{
+    contracts::darkpool::{
+        PlonkProof as ContractPlonkProof, TransferAuthorization as ContractTransferAuth,
+        ValidWalletUpdateStatement as ContractValidWalletUpdateStatement,
+    },
+    util::{fetch_merkle_opening, send_tx, WrapEyre},
+    TestArgs,
+};
+
+use super::create_wallet::create_darkpool_wallet;
 
 /// Update a wallet by placing an order
 #[allow(non_snake_case)]
-async fn test_update_wallet__place_order(args: TestArgs) -> Result<(), eyre::Error> {
-    let wallet = args.wallet.clone();
+async fn test_update_wallet__place_and_cancel_order(args: TestArgs) -> Result<(), eyre::Error> {
+    let mut wallet = create_darkpool_wallet(&args).await?;
     let darkpool = args.darkpool.clone();
+
+    // Add an order to the wallet
+    let mut old_wallet = wallet.clone();
+    let old_wallet_comm = old_wallet.get_wallet_share_commitment();
+    let opening = fetch_merkle_opening(old_wallet_comm, &darkpool).await?;
+    old_wallet.merkle_proof = Some(opening);
+
+    let id = OrderIdentifier::new_v4();
+    let order = dummy_order();
+    wallet.add_order(id, order).unwrap();
+    wallet.reblind_wallet();
+    submit_wallet_update(old_wallet, wallet.clone(), &args).await?;
+
+    // Cancel the order
+    let mut old_wallet = wallet.clone();
+    let old_wallet_comm = old_wallet.get_wallet_share_commitment();
+    let opening = fetch_merkle_opening(old_wallet_comm, &darkpool).await?;
+    old_wallet.merkle_proof = Some(opening);
+
+    wallet.remove_order(&id).unwrap();
+    wallet.reblind_wallet();
+    submit_wallet_update(old_wallet, wallet, &args).await?;
 
     Ok(())
 }
-integration_test_async!(test_update_wallet__place_order);
+integration_test_async!(test_update_wallet__place_and_cancel_order);
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Submit an update wallet transaction
+async fn submit_wallet_update(
+    old_wallet: Wallet,
+    new_wallet: Wallet,
+    args: &TestArgs,
+) -> Result<()> {
+    let transfer = ExternalTransfer::default();
+    submit_wallet_update_with_transfer(old_wallet, new_wallet, transfer, args).await
+}
+
+/// Submit an update wallet transaction with an external transfer
+async fn submit_wallet_update_with_transfer(
+    old_wallet: Wallet,
+    new_wallet: Wallet,
+    transfer: ExternalTransfer,
+    args: &TestArgs,
+) -> Result<(), eyre::Error> {
+    // Choose the correct balance index for the transfer
+    let transfer_idx = if transfer.is_default() {
+        0
+    } else if transfer.direction == ExternalTransferDirection::Deposit {
+        // Find the balance in the new wallet that the transfer applies to
+        new_wallet.get_balance_index(&transfer.mint).unwrap()
+    } else {
+        // Find the balance in the old wallet that the transfer applies to
+        old_wallet.get_balance_index(&transfer.mint).unwrap()
+    };
+
+    // Add update and transfer auth
+    // TODO: transfer auth
+    let new_wallet_comm = new_wallet.get_wallet_share_commitment();
+    let update_sig = old_wallet.sign_commitment(new_wallet_comm).to_eyre()?;
+    let update_sig_bytes = Bytes::from(update_sig.to_vec());
+    let transfer_auth = ContractTransferAuth {
+        permit2Deadline: U256::from(0),
+        permit2Nonce: U256::from(0),
+        permit2Signature: Bytes::from(vec![]),
+        externalTransferSignature: Bytes::from(vec![]),
+    };
+
+    // Prove the update
+    let (statement, proof) = prove_wallet_update(old_wallet, new_wallet, transfer, transfer_idx)?;
+    let statement: ContractValidWalletUpdateStatement = statement.into();
+    let proof: ContractPlonkProof = proof.into();
+
+    // Submit the proof to the darkpool
+    let tx = args
+        .darkpool
+        .updateWallet(update_sig_bytes, transfer_auth, statement, proof);
+    let receipt = send_tx(tx).await?;
+
+    Ok(())
+}
+
+/// Prove a `VALID WALLET UPDATE` statement
+fn prove_wallet_update(
+    old_wallet: Wallet,
+    new_wallet: Wallet,
+    transfer: ExternalTransfer,
+    transfer_idx: usize,
+) -> Result<(SizedValidWalletUpdateStatement, PlonkProof)> {
+    let (witness, statement) =
+        build_witness_statement(old_wallet, new_wallet, transfer, transfer_idx)?;
+    let proof = singleprover_prove::<SizedValidWalletUpdate>(witness, statement.clone())?;
+
+    Ok((statement, proof))
+}
+
+/// Build a witness and statement for a proof of `VALID WALLET UPDATE`
+fn build_witness_statement(
+    old_wallet: Wallet,
+    new_wallet: Wallet,
+    transfer: ExternalTransfer,
+    transfer_idx: usize,
+) -> Result<(
+    SizedValidWalletUpdateWitness,
+    SizedValidWalletUpdateStatement,
+)> {
+    let old_wallet_nullifier = old_wallet.get_wallet_nullifier();
+    let old_wallet_merkle = old_wallet.merkle_proof.unwrap().clone();
+    let old_wallet_merkle_root = old_wallet_merkle.compute_root();
+    let new_wallet_commitment = new_wallet.get_private_share_commitment();
+    let merkle_proof = old_wallet_merkle.into();
+
+    Ok((
+        SizedValidWalletUpdateWitness {
+            old_wallet_private_shares: old_wallet.private_shares,
+            old_wallet_public_shares: old_wallet.blinded_public_shares,
+            old_shares_opening: merkle_proof,
+            new_wallet_private_shares: new_wallet.private_shares,
+            transfer_index: transfer_idx,
+        },
+        SizedValidWalletUpdateStatement {
+            old_shares_nullifier: old_wallet_nullifier,
+            new_private_shares_commitment: new_wallet_commitment,
+            new_public_shares: new_wallet.blinded_public_shares,
+            merkle_root: old_wallet_merkle_root,
+            external_transfer: transfer,
+            old_pk_root: old_wallet.key_chain.public_keys.pk_root,
+        },
+    ))
+}
+
+/// Create a dummy order
+fn dummy_order() -> Order {
+    let quote = BigUint::from(1u8);
+    let base = BigUint::from(2u8);
+    Order {
+        quote_mint: quote,
+        base_mint: base,
+        side: OrderSide::Buy,
+        amount: 10_000,
+        worst_case_price: FixedPoint::from_f64_round_down(1500.),
+        ..Default::default()
+    }
+}

--- a/integration/src/tests/update_wallet.rs
+++ b/integration/src/tests/update_wallet.rs
@@ -1,0 +1,15 @@
+//! Wallet update tests
+
+use test_helpers::integration_test_async;
+
+use crate::TestArgs;
+
+/// Update a wallet by placing an order
+#[allow(non_snake_case)]
+async fn test_update_wallet__place_order(args: TestArgs) -> Result<(), eyre::Error> {
+    let wallet = args.wallet.clone();
+    let darkpool = args.darkpool.clone();
+
+    Ok(())
+}
+integration_test_async!(test_update_wallet__place_order);

--- a/integration/src/util.rs
+++ b/integration/src/util.rs
@@ -127,3 +127,27 @@ pub async fn call_helper<C: CallDecoder + Unpin>(
     let res = call.call().await?;
     Ok(res)
 }
+
+// ----------
+// | Errors |
+// ----------
+
+/// A trait with auto-implementation that makes it easier to convert errors to `eyre::Result`
+pub trait WrapEyre {
+    /// The type of the value being wrapped
+    type Value;
+
+    /// Convert the error to an eyre::Result
+    fn to_eyre(self) -> Result<Self::Value>;
+}
+
+impl<R, E: ToString> WrapEyre for core::result::Result<R, E> {
+    type Value = R;
+
+    fn to_eyre(self) -> Result<R> {
+        match self {
+            Ok(r) => Ok(r),
+            Err(e) => Err(eyre::eyre!(e.to_string())),
+        }
+    }
+}

--- a/script/start_dev_node.sh
+++ b/script/start_dev_node.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Default anvil private key
+ANVIL_PKEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+# Function to cleanup anvil process
+cleanup() {
+    echo "Cleaning up anvil process..."
+    if [ ! -z "$ANVIL_PID" ]; then
+        kill $ANVIL_PID
+    fi
+}
+
+# Set up trap for cleanup on script exit
+trap cleanup EXIT
+
+# Start anvil in the background
+echo "Starting anvil node..."
+anvil &
+ANVIL_PID=$!
+
+# Wait for anvil to start
+sleep 2
+
+# Run the deployment script
+echo "Running deployment script..."
+forge script script/DeployDev.s.sol \
+    --ffi \
+    --rpc-url http://localhost:8545 \
+    --private-key $ANVIL_PKEY \
+    --broadcast
+
+# Keep the script running until interrupted
+echo "Deployment complete. Press Ctrl+C to exit..."
+while true; do
+    sleep 1
+done 


### PR DESCRIPTION
### Purpose
This PR adds basic integration tests for the `updateWallet` method in the darkpool. Currently the tests do not test transfers, those will come in a follow up.

### Todo
- Test transfers

### Testing
- All unit tests pass
- All integration tests pass