### PR TITLE
integration: tests: update-wallet: Add withdrawal tests

### DIFF
--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -19,7 +19,12 @@ renegade-common = { package = "common", git = "https://github.com/renegade-fi/re
     "all-types",
 ] }
 renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade" }
-test-helpers = { git = "https://github.com/renegade-fi/renegade" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade", features = [
+    "blockchain",
+] }
+test-helpers = { git = "https://github.com/renegade-fi/renegade", features = [
+    "contracts",
+] }
 
 # === Alloy Dependencies === #
 alloy = { version = "0.12", features = ["essentials"] }

--- a/integration/src/contracts/darkpool.rs
+++ b/integration/src/contracts/darkpool.rs
@@ -39,3 +39,15 @@ impl Default for TransferAuthorization {
         }
     }
 }
+
+impl TransferAuthorization {
+    /// Create a withdrawal authorization
+    pub fn withdrawal(sig_bytes: Vec<u8>) -> Self {
+        Self {
+            permit2Nonce: U256::ZERO,
+            permit2Deadline: U256::ZERO,
+            permit2Signature: Bytes::new(),
+            externalTransferSignature: Bytes::from(sig_bytes),
+        }
+    }
+}

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Script.sol";
+import "permit2/interfaces/IPermit2.sol";
+import "renegade-lib/interfaces/IWETH9.sol";
 import "./utils/DeployUtils.sol";
 
 contract DeployScript is Script {
@@ -20,6 +22,6 @@ contract DeployScript is Script {
 
     function run(address permit2Address, address wethAddress, address protocolFeeAddr) public {
         // Call the shared deployment logic
-        DeployUtils.deployCore(permit2Address, wethAddress, protocolFeeAddr, vm);
+        DeployUtils.deployCore(IPermit2(permit2Address), IWETH9(wethAddress), protocolFeeAddr, vm);
     }
 }

--- a/script/run-integration-tests.sh
+++ b/script/run-integration-tests.sh
@@ -113,14 +113,12 @@ if [ "$SKIP_TESTS" = false ]; then
             exit 1
         fi
     fi
+    echo "Tests completed successfully. Exiting..."
+    exit 0
 fi
 
-# Keep the script running until interrupted
-if [ "$SKIP_TESTS" = true ]; then
-    echo "Anvil node is running. Press Ctrl+C to exit..."
-else
-    echo "Deployment and all tests complete. Press Ctrl+C to exit..."
-fi
+# If we're not running tests, keep the script running until interrupted
+echo "Anvil node is running. Press Ctrl+C to exit..."
 while true; do
     sleep 1
 done 


### PR DESCRIPTION
### Purpose
This PR adds integration tests for the withdrawal case in an `updateWallet`. This involves changing the way the utils sign the withdrawal, as the solidity serialization is different from the one used in our stylus implementation. We use `abi_encode` while the stylus crate uses `postcard`.

### Testing
- [x] Unit tests pass
- [x] Integration tests pass