### PR TITLE
Darkpool.sol: Add owner methods and require owner on admin interface

### DIFF
--- a/test/darkpool/AdminMethods.t.sol
+++ b/test/darkpool/AdminMethods.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { DarkpoolTestBase } from "./DarkpoolTestBase.sol";
+import { EncryptionKey } from "renegade-lib/darkpool/types/Ciphertext.sol";
+
+contract AdminMethodsTest is DarkpoolTestBase {
+    // --- Constants --- //
+    bytes4 constant UNAUTHORIZED_ACCOUNT_ERROR = bytes4(keccak256("OwnableUnauthorizedAccount(address)"));
+
+    // --- Admin Methods --- //
+
+    /// @notice Test the owner method
+    function test_getOwner() public view {
+        assertEq(darkpool.owner(), darkpoolOwner);
+    }
+
+    /// @notice Test setting the protocol fee rate
+    function test_setProtocolFeeRate() public {
+        uint256 newFee = 10;
+
+        // Try without the owner
+        vm.expectPartialRevert(UNAUTHORIZED_ACCOUNT_ERROR);
+        darkpool.setProtocolFeeRate(newFee);
+
+        // Try to set the fee to zero
+        vm.expectRevert("Fee cannot be zero");
+        vm.prank(darkpoolOwner);
+        darkpool.setProtocolFeeRate(0);
+
+        // Set the new fee
+        vm.prank(darkpoolOwner);
+        darkpool.setProtocolFeeRate(newFee);
+        assertEq(darkpool.protocolFeeRate(), newFee);
+    }
+
+    /// @notice Test setting the external match fee rate for a token
+    function test_setTokenExternalMatchFeeRate() public {
+        address token = vm.randomAddress();
+        uint256 newFee = 10;
+
+        // Try without the owner
+        vm.expectPartialRevert(UNAUTHORIZED_ACCOUNT_ERROR);
+        darkpool.setTokenExternalMatchFeeRate(token, newFee);
+
+        // Set the new fee
+        vm.prank(darkpoolOwner);
+        darkpool.setTokenExternalMatchFeeRate(token, newFee);
+        assertEq(darkpool.getTokenExternalMatchFeeRate(token), newFee);
+
+        // Remove the fee override without the owner
+        vm.expectPartialRevert(UNAUTHORIZED_ACCOUNT_ERROR);
+        darkpool.removeTokenExternalMatchFeeRate(token);
+
+        // Remove the fee override with the owner
+        vm.prank(darkpoolOwner);
+        darkpool.removeTokenExternalMatchFeeRate(token);
+        assertEq(darkpool.getTokenExternalMatchFeeRate(token), darkpool.protocolFeeRate());
+    }
+
+    /// @notice Set the protocol fee encryption key
+    function test_setProtocolFeeKey() public {
+        uint256 newPubkeyX = 1;
+        uint256 newPubkeyY = 2;
+
+        // Try without the owner
+        vm.expectPartialRevert(UNAUTHORIZED_ACCOUNT_ERROR);
+        darkpool.setProtocolFeeKey(newPubkeyX, newPubkeyY);
+
+        // Set the new key
+        vm.prank(darkpoolOwner);
+        darkpool.setProtocolFeeKey(newPubkeyX, newPubkeyY);
+
+        EncryptionKey memory key = darkpool.getProtocolFeeKey();
+        assertEq(BN254.ScalarField.unwrap(key.point.x), newPubkeyX);
+        assertEq(BN254.ScalarField.unwrap(key.point.y), newPubkeyY);
+    }
+
+    /// @notice Test setting the protocol fee recipient
+    function test_setProtocolFeeRecipient() public {
+        address newRecipient = vm.randomAddress();
+
+        // Try without the owner
+        vm.expectPartialRevert(UNAUTHORIZED_ACCOUNT_ERROR);
+        darkpool.setProtocolFeeRecipient(newRecipient);
+
+        // Set the new recipient
+        vm.prank(darkpoolOwner);
+        darkpool.setProtocolFeeRecipient(newRecipient);
+        assertEq(darkpool.getProtocolFeeRecipient(), newRecipient);
+    }
+}

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -39,6 +39,7 @@ contract DarkpoolTestBase is CalldataUtils {
     IVKeys public vkeys;
 
     address public protocolFeeAddr;
+    address public darkpoolOwner;
 
     bytes constant INVALID_NULLIFIER_REVERT_STRING = "nullifier/blinder already spent";
     bytes constant INVALID_ROOT_REVERT_STRING = "Merkle root not in history";
@@ -69,10 +70,16 @@ contract DarkpoolTestBase is CalldataUtils {
         vkeys = new VKeys();
         IVerifier verifier = new TestVerifier(vkeys);
         IVerifier realVerifier = new Verifier(vkeys);
-        protocolFeeAddr = vm.randomAddress();
         EncryptionKey memory protocolFeeKey = randomEncryptionKey();
 
+        // Deploy the darkpool
+        darkpoolOwner = vm.randomAddress();
+        protocolFeeAddr = vm.randomAddress();
+
+        vm.prank(darkpoolOwner);
         darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, verifier, permit2);
+
+        vm.prank(darkpoolOwner);
         darkpoolRealVerifier =
             new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, realVerifier, permit2);
     }


### PR DESCRIPTION
### Purpose
This PR makes the darkpool `Ownable` using the OpenZeppelin `Ownable` interface. We then add modifiers to all admin methods enforcing that they only be called by the owner.

### Tesitng
- [x] All unit tests pass
- [x] Added tests for all admin methods checking that they can only be called by the owner