### PR TITLE
Darkpool.sol: Make darkpool pausable by owner

### DIFF
--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -361,6 +361,7 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
 
         // Setup the protocol fee rate
         uint256 protocolFeeRate = 4_611_686_018_427_388; // 0.0005 * 2 ** `FIXED_POINT_PRECISION`
+        vm.prank(darkpoolOwner);
         darkpool.setTokenExternalMatchFeeRate(address(baseToken), protocolFeeRate);
         assertEq(darkpool.getTokenExternalMatchFeeRate(address(baseToken)), protocolFeeRate);
 


### PR DESCRIPTION
### Purpose
This PR makes the Darkpool pausable by the owner. When paused, only getter methods are enabled on the darkpool.


### Testing
- [x] Unit tests pass
- [x] Tested pause/unpause behavior