### PR TITLE
Darkpool.sol, TransferExecutor.sol: Split transfers into library contract

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,13 +6,14 @@ libs = ["lib"]
 remappings = ["forge-std/=lib/forge-std/src/"]
 via_ir = true
 optimizer = true
-optimizer_runs = 20_000
+optimizer_runs = 100_000
 fs_permissions = [{ access = "read-write", path = "./deployments.json" }]
 
 # The darkpool is a large contract so we limit the optimizer runs
-additional_compiler_profiles = [{ name = "darkpool", optimizer_runs = 100 }]
+# Todo: if more space is needed, decrease the number of runs
+additional_compiler_profiles = [{ name = "darkpool", optimizer_runs = 18_000 }]
 compilation_restrictions = [
-    { paths = "src/Darkpool.sol", optimizer_runs = 100 },
+    { paths = "src/Darkpool.sol", optimizer_runs = 18_000 },
 ]
 
 [fmt]

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,8 +6,14 @@ libs = ["lib"]
 remappings = ["forge-std/=lib/forge-std/src/"]
 via_ir = true
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 20_000
 fs_permissions = [{ access = "read-write", path = "./deployments.json" }]
+
+# The darkpool is a large contract so we limit the optimizer runs
+additional_compiler_profiles = [{ name = "darkpool", optimizer_runs = 100 }]
+compilation_restrictions = [
+    { paths = "src/Darkpool.sol", optimizer_runs = 100 },
+]
 
 [fmt]
 line_length = 120

--- a/src/TransferExecutor.sol
+++ b/src/TransferExecutor.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
+
+import { TypesLib } from "renegade-lib/darkpool/types/TypesLib.sol";
+import { ExternalTransferLib } from "renegade-lib/darkpool/ExternalTransfers.sol";
+import { ExternalTransfer, TransferAuthorization } from "renegade-lib/darkpool/types/Transfers.sol";
+import { PublicRootKey } from "renegade-lib/darkpool/types/Keychain.sol";
+import { ExternalMatchResult, ExternalMatchDirection } from "renegade-lib/darkpool/types/Settlement.sol";
+import { FeeTake } from "renegade-lib/darkpool/types/Fees.sol";
+import { DarkpoolConstants } from "renegade-lib/darkpool/Constants.sol";
+
+/// @title TransferExecutor
+/// @notice A contract that executes external transfers for the Darkpool contract
+/// @dev This contract is designed to be used with delegatecall from the Darkpool contract
+contract TransferExecutor {
+    using TypesLib for ExternalMatchResult;
+    using TypesLib for FeeTake;
+
+    /// @notice Executes a single external transfer
+    /// @param transfer The external transfer to execute
+    /// @param oldPkRoot The public root key of the sender's Renegade wallet
+    /// @param transferAuthorization The authorization data for the transfer
+    /// @param permit2 The Permit2 contract instance for handling deposits
+    function executeTransfer(
+        ExternalTransfer calldata transfer,
+        PublicRootKey calldata oldPkRoot,
+        TransferAuthorization calldata transferAuthorization,
+        IPermit2 permit2
+    )
+        external
+    {
+        ExternalTransferLib.executeTransfer(transfer, oldPkRoot, transferAuthorization, permit2);
+    }
+
+    /// @notice Builds and executes a batch of transfers for an atomic match
+    /// @param externalParty The address of the external party
+    /// @param relayerFeeAddr The address to receive relayer fees
+    /// @param protocolFeeRecipient The address to receive protocol fees
+    /// @param matchResult The result of the match
+    /// @param feeTake The fee take information
+    /// @param weth The WETH9 contract for native token handling
+    function executeAtomicMatchTransfers(
+        address externalParty,
+        address relayerFeeAddr,
+        address protocolFeeRecipient,
+        ExternalMatchResult calldata matchResult,
+        FeeTake calldata feeTake,
+        IWETH9 weth
+    )
+        external
+        payable
+    {
+        ExternalTransferLib.SimpleTransfer[] memory transfers =
+            buildAtomicMatchTransfers(externalParty, relayerFeeAddr, protocolFeeRecipient, matchResult, feeTake);
+
+        ExternalTransferLib.executeTransferBatch(transfers, weth);
+    }
+
+    /// @notice Build a list of simple transfers to settle an atomic match
+    /// @param externalParty The address of the external party
+    /// @param relayerFeeAddr The address to receive relayer fees
+    /// @param protocolFeeRecipient The address to receive protocol fees
+    /// @param matchResult The result of the match
+    /// @param feeTake The fee take information
+    /// @return transfers An array of simple transfers to execute
+    function buildAtomicMatchTransfers(
+        address externalParty,
+        address relayerFeeAddr,
+        address protocolFeeRecipient,
+        ExternalMatchResult memory matchResult,
+        FeeTake memory feeTake
+    )
+        public
+        view
+        returns (ExternalTransferLib.SimpleTransfer[] memory transfers)
+    {
+        (address sellMint, uint256 sellAmount) = matchResult.externalPartySellMintAmount();
+        (address buyMint, uint256 buyAmount) = matchResult.externalPartyBuyMintAmount();
+
+        // Build the transfers
+        transfers = new ExternalTransferLib.SimpleTransfer[](4);
+
+        // 1. Deposit the sell amount
+        transfers[0] = ExternalTransferLib.SimpleTransfer({
+            account: msg.sender,
+            mint: sellMint,
+            amount: sellAmount,
+            transferType: ExternalTransferLib.SimpleTransferType.Deposit
+        });
+
+        // 2. Withdraw the buy amount net of fees
+        // Tx will revert if the buy amount is less than the total fees
+        uint256 totalFees = feeTake.total();
+        uint256 traderTake = buyAmount - totalFees;
+        transfers[1] = ExternalTransferLib.SimpleTransfer({
+            account: externalParty,
+            mint: buyMint,
+            amount: traderTake,
+            transferType: ExternalTransferLib.SimpleTransferType.Withdrawal
+        });
+
+        // 3. Withdraw the relayer's fee on the external party to the relayer
+        transfers[2] = ExternalTransferLib.SimpleTransfer({
+            account: relayerFeeAddr,
+            mint: buyMint,
+            amount: feeTake.relayerFee,
+            transferType: ExternalTransferLib.SimpleTransferType.Withdrawal
+        });
+
+        // 4. Withdraw the protocol's fee on the external party to the protocol
+        transfers[3] = ExternalTransferLib.SimpleTransfer({
+            account: protocolFeeRecipient,
+            mint: buyMint,
+            amount: feeTake.protocolFee,
+            transferType: ExternalTransferLib.SimpleTransferType.Withdrawal
+        });
+    }
+}

--- a/src/libraries/darkpool/ExternalTransfers.sol
+++ b/src/libraries/darkpool/ExternalTransfers.sol
@@ -17,10 +17,10 @@ import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
-/// @title TransferExecutor
+/// @title ExternalTransferLib
 /// @notice This library implements the logic for executing external transfers
 /// @notice External transfers are either deposits or withdrawals into/from the darkpool
-library TransferExecutor {
+library ExternalTransferLib {
     using TypesLib for DepositWitness;
 
     // --- Types --- //

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -15,6 +15,7 @@ import { PublicRootKey } from "renegade-lib/darkpool/types/Keychain.sol";
 import { EncryptionKey } from "renegade-lib/darkpool/types/Ciphertext.sol";
 import { TestVerifier } from "../test-contracts/TestVerifier.sol";
 import { Darkpool } from "renegade/Darkpool.sol";
+import { TransferExecutor } from "renegade/TransferExecutor.sol";
 import { NullifierLib } from "renegade-lib/darkpool/NullifierSet.sol";
 import { WalletOperations } from "renegade-lib/darkpool/WalletOperations.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
@@ -37,6 +38,7 @@ contract DarkpoolTestBase is CalldataUtils {
     ERC20Mock public baseToken;
     WethMock public weth;
     IVKeys public vkeys;
+    TransferExecutor public transferExecutor;
 
     address public protocolFeeAddr;
     address public darkpoolOwner;
@@ -72,16 +74,36 @@ contract DarkpoolTestBase is CalldataUtils {
         IVerifier realVerifier = new Verifier(vkeys);
         EncryptionKey memory protocolFeeKey = randomEncryptionKey();
 
+        // Deploy TransferExecutor
+        transferExecutor = new TransferExecutor();
+
         // Deploy the darkpool
         darkpoolOwner = vm.randomAddress();
         protocolFeeAddr = vm.randomAddress();
 
         vm.prank(darkpoolOwner);
-        darkpool = new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, verifier, permit2);
+        darkpool = new Darkpool(
+            TEST_PROTOCOL_FEE,
+            protocolFeeAddr,
+            protocolFeeKey,
+            weth,
+            hasher,
+            verifier,
+            permit2,
+            address(transferExecutor)
+        );
 
         vm.prank(darkpoolOwner);
-        darkpoolRealVerifier =
-            new Darkpool(TEST_PROTOCOL_FEE, protocolFeeAddr, protocolFeeKey, weth, hasher, realVerifier, permit2);
+        darkpoolRealVerifier = new Darkpool(
+            TEST_PROTOCOL_FEE,
+            protocolFeeAddr,
+            protocolFeeKey,
+            weth,
+            hasher,
+            realVerifier,
+            permit2,
+            address(transferExecutor)
+        );
     }
 
     /// @dev Get the base and quote token amounts for an address


### PR DESCRIPTION
### Purpose
This PR splits the `ExternalTransferLib` into a separate library contract to reduce the size of the darkpool contract, then tunes the optimizer runs used when `solc` compiles `Darkpool.sol`. All contracts now fit in the bytecode size limit.

### Testing
- [x] Unit tests pass
- [x] Integration tests pass. This implicitly tests bytecode limits, as we deploy to an anvil node.