### PR TITLE
darkpool: PublicInputs: Update statement types for full commitments

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,10 +11,8 @@ fs_permissions = [{ access = "read-write", path = "./deployments.json" }]
 
 # The darkpool is a large contract so we limit the optimizer runs
 # Todo: if more space is needed, decrease the number of runs
-additional_compiler_profiles = [{ name = "darkpool", optimizer_runs = 18_000 }]
-compilation_restrictions = [
-    { paths = "src/Darkpool.sol", optimizer_runs = 18_000 },
-]
+additional_compiler_profiles = [{ name = "darkpool", optimizer_runs = 1 }]
+compilation_restrictions = [{ paths = "src/Darkpool.sol", optimizer_runs = 1 }]
 
 [fmt]
 line_length = 120

--- a/integration/src/contracts/abis/IDarkpool.json
+++ b/integration/src/contracts/abis/IDarkpool.json
@@ -1,1 +1,3713 @@
-{"abi":[{"type":"function","name":"createWallet","inputs":[{"name":"statement","type":"tuple","internalType":"struct ValidWalletCreateStatement","components":[{"name":"privateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"publicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"}]},{"name":"proof","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"getMerkleRoot","inputs":[],"outputs":[{"name":"","type":"uint256","internalType":"BN254.ScalarField"}],"stateMutability":"view"},{"type":"function","name":"getProtocolFeeKey","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct EncryptionKey","components":[{"name":"point","type":"tuple","internalType":"struct BabyJubJubPoint","components":[{"name":"x","type":"uint256","internalType":"BN254.ScalarField"},{"name":"y","type":"uint256","internalType":"BN254.ScalarField"}]}]}],"stateMutability":"view"},{"type":"function","name":"getTokenExternalMatchFeeRate","inputs":[{"name":"asset","type":"address","internalType":"address"}],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"hasher","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IHasher"}],"stateMutability":"view"},{"type":"function","name":"nullifierSpent","inputs":[{"name":"nullifier","type":"uint256","internalType":"BN254.ScalarField"}],"outputs":[{"name":"","type":"bool","internalType":"bool"}],"stateMutability":"view"},{"type":"function","name":"perTokenFeeOverrides","inputs":[{"name":"","type":"address","internalType":"address"}],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"permit2","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IPermit2"}],"stateMutability":"view"},{"type":"function","name":"processAtomicMatchSettle","inputs":[{"name":"internalPartyPayload","type":"tuple","internalType":"struct PartyMatchPayload","components":[{"name":"validCommitmentsStatement","type":"tuple","internalType":"struct ValidCommitmentsStatement","components":[{"name":"indices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]}]},{"name":"validReblindStatement","type":"tuple","internalType":"struct ValidReblindStatement","components":[{"name":"originalSharesNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPrivateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"matchSettleStatement","type":"tuple","internalType":"struct ValidMatchSettleAtomicStatement","components":[{"name":"matchResult","type":"tuple","internalType":"struct ExternalMatchResult","components":[{"name":"quoteMint","type":"address","internalType":"address"},{"name":"baseMint","type":"address","internalType":"address"},{"name":"quoteAmount","type":"uint256","internalType":"uint256"},{"name":"baseAmount","type":"uint256","internalType":"uint256"},{"name":"direction","type":"uint8","internalType":"enum ExternalMatchDirection"}]},{"name":"externalPartyFees","type":"tuple","internalType":"struct FeeTake","components":[{"name":"relayerFee","type":"uint256","internalType":"uint256"},{"name":"protocolFee","type":"uint256","internalType":"uint256"}]},{"name":"internalPartyModifiedShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"internalPartySettlementIndices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]},{"name":"protocolFeeRate","type":"uint256","internalType":"uint256"},{"name":"relayerFeeAddress","type":"address","internalType":"address"}]},{"name":"proofs","type":"tuple","internalType":"struct MatchAtomicProofs","components":[{"name":"validCommitments","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validReblind","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validMatchSettleAtomic","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"linkingProofs","type":"tuple","internalType":"struct MatchAtomicLinkingProofs","components":[{"name":"validReblindCommitments","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]},{"name":"validCommitmentsMatchSettleAtomic","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]}]}],"outputs":[],"stateMutability":"payable"},{"type":"function","name":"processAtomicMatchSettleWithReceiver","inputs":[{"name":"receiver","type":"address","internalType":"address"},{"name":"internalPartyPayload","type":"tuple","internalType":"struct PartyMatchPayload","components":[{"name":"validCommitmentsStatement","type":"tuple","internalType":"struct ValidCommitmentsStatement","components":[{"name":"indices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]}]},{"name":"validReblindStatement","type":"tuple","internalType":"struct ValidReblindStatement","components":[{"name":"originalSharesNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPrivateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"matchSettleStatement","type":"tuple","internalType":"struct ValidMatchSettleAtomicStatement","components":[{"name":"matchResult","type":"tuple","internalType":"struct ExternalMatchResult","components":[{"name":"quoteMint","type":"address","internalType":"address"},{"name":"baseMint","type":"address","internalType":"address"},{"name":"quoteAmount","type":"uint256","internalType":"uint256"},{"name":"baseAmount","type":"uint256","internalType":"uint256"},{"name":"direction","type":"uint8","internalType":"enum ExternalMatchDirection"}]},{"name":"externalPartyFees","type":"tuple","internalType":"struct FeeTake","components":[{"name":"relayerFee","type":"uint256","internalType":"uint256"},{"name":"protocolFee","type":"uint256","internalType":"uint256"}]},{"name":"internalPartyModifiedShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"internalPartySettlementIndices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]},{"name":"protocolFeeRate","type":"uint256","internalType":"uint256"},{"name":"relayerFeeAddress","type":"address","internalType":"address"}]},{"name":"proofs","type":"tuple","internalType":"struct MatchAtomicProofs","components":[{"name":"validCommitments","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validReblind","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validMatchSettleAtomic","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"linkingProofs","type":"tuple","internalType":"struct MatchAtomicLinkingProofs","components":[{"name":"validReblindCommitments","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]},{"name":"validCommitmentsMatchSettleAtomic","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]}]}],"outputs":[],"stateMutability":"payable"},{"type":"function","name":"processMalleableAtomicMatchSettle","inputs":[{"name":"baseAmount","type":"uint256","internalType":"uint256"},{"name":"receiver","type":"address","internalType":"address"},{"name":"internalPartyPayload","type":"tuple","internalType":"struct PartyMatchPayload","components":[{"name":"validCommitmentsStatement","type":"tuple","internalType":"struct ValidCommitmentsStatement","components":[{"name":"indices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]}]},{"name":"validReblindStatement","type":"tuple","internalType":"struct ValidReblindStatement","components":[{"name":"originalSharesNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPrivateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"matchSettleStatement","type":"tuple","internalType":"struct ValidMalleableMatchSettleAtomicStatement","components":[{"name":"matchResult","type":"tuple","internalType":"struct BoundedMatchResult","components":[{"name":"quoteMint","type":"address","internalType":"address"},{"name":"baseMint","type":"address","internalType":"address"},{"name":"price","type":"tuple","internalType":"struct FixedPoint","components":[{"name":"repr","type":"uint256","internalType":"uint256"}]},{"name":"minBaseAmount","type":"uint256","internalType":"uint256"},{"name":"maxBaseAmount","type":"uint256","internalType":"uint256"},{"name":"direction","type":"uint8","internalType":"enum ExternalMatchDirection"}]},{"name":"externalFeeRates","type":"tuple","internalType":"struct FeeTakeRate","components":[{"name":"relayerFeeRate","type":"tuple","internalType":"struct FixedPoint","components":[{"name":"repr","type":"uint256","internalType":"uint256"}]},{"name":"protocolFeeRate","type":"tuple","internalType":"struct FixedPoint","components":[{"name":"repr","type":"uint256","internalType":"uint256"}]}]},{"name":"internalFeeRates","type":"tuple","internalType":"struct FeeTakeRate","components":[{"name":"relayerFeeRate","type":"tuple","internalType":"struct FixedPoint","components":[{"name":"repr","type":"uint256","internalType":"uint256"}]},{"name":"protocolFeeRate","type":"tuple","internalType":"struct FixedPoint","components":[{"name":"repr","type":"uint256","internalType":"uint256"}]}]},{"name":"internalPartyPublicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"relayerFeeAddress","type":"address","internalType":"address"}]},{"name":"proofs","type":"tuple","internalType":"struct MalleableMatchAtomicProofs","components":[{"name":"validCommitments","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validReblind","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validMalleableMatchSettleAtomic","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"linkingProofs","type":"tuple","internalType":"struct MatchAtomicLinkingProofs","components":[{"name":"validReblindCommitments","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]},{"name":"validCommitmentsMatchSettleAtomic","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]}]}],"outputs":[],"stateMutability":"payable"},{"type":"function","name":"processMatchSettle","inputs":[{"name":"party0MatchPayload","type":"tuple","internalType":"struct PartyMatchPayload","components":[{"name":"validCommitmentsStatement","type":"tuple","internalType":"struct ValidCommitmentsStatement","components":[{"name":"indices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]}]},{"name":"validReblindStatement","type":"tuple","internalType":"struct ValidReblindStatement","components":[{"name":"originalSharesNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPrivateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"party1MatchPayload","type":"tuple","internalType":"struct PartyMatchPayload","components":[{"name":"validCommitmentsStatement","type":"tuple","internalType":"struct ValidCommitmentsStatement","components":[{"name":"indices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]}]},{"name":"validReblindStatement","type":"tuple","internalType":"struct ValidReblindStatement","components":[{"name":"originalSharesNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPrivateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"matchSettleStatement","type":"tuple","internalType":"struct ValidMatchSettleStatement","components":[{"name":"firstPartyPublicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"secondPartyPublicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"firstPartySettlementIndices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]},{"name":"secondPartySettlementIndices","type":"tuple","internalType":"struct OrderSettlementIndices","components":[{"name":"balanceSend","type":"uint256","internalType":"uint256"},{"name":"balanceReceive","type":"uint256","internalType":"uint256"},{"name":"order","type":"uint256","internalType":"uint256"}]},{"name":"protocolFeeRate","type":"uint256","internalType":"uint256"}]},{"name":"proofs","type":"tuple","internalType":"struct MatchProofs","components":[{"name":"validCommitments0","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validReblind0","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validCommitments1","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validReblind1","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"validMatchSettle","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"linkingProofs","type":"tuple","internalType":"struct MatchLinkingProofs","components":[{"name":"validReblindCommitments0","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]},{"name":"validCommitmentsMatchSettle0","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]},{"name":"validReblindCommitments1","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]},{"name":"validCommitmentsMatchSettle1","type":"tuple","internalType":"struct LinkingProof","components":[{"name":"linking_quotient_poly_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"linking_poly_opening","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]}]}]}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"protocolFeeKey","inputs":[],"outputs":[{"name":"","type":"tuple","internalType":"struct EncryptionKey","components":[{"name":"point","type":"tuple","internalType":"struct BabyJubJubPoint","components":[{"name":"x","type":"uint256","internalType":"BN254.ScalarField"},{"name":"y","type":"uint256","internalType":"BN254.ScalarField"}]}]}],"stateMutability":"view"},{"type":"function","name":"protocolFeeRate","inputs":[],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"protocolFeeRecipient","inputs":[],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"redeemFee","inputs":[{"name":"recipientCommitmentSig","type":"bytes","internalType":"bytes"},{"name":"statement","type":"tuple","internalType":"struct ValidFeeRedemptionStatement","components":[{"name":"walletRoot","type":"uint256","internalType":"BN254.ScalarField"},{"name":"noteRoot","type":"uint256","internalType":"BN254.ScalarField"},{"name":"walletNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"noteNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newWalletCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newWalletPublicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"walletRootKey","type":"tuple","internalType":"struct PublicRootKey","components":[{"name":"x","type":"uint256[2]","internalType":"BN254.ScalarField[2]"},{"name":"y","type":"uint256[2]","internalType":"BN254.ScalarField[2]"}]}]},{"name":"proof","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"rootInHistory","inputs":[{"name":"root","type":"uint256","internalType":"BN254.ScalarField"}],"outputs":[{"name":"","type":"bool","internalType":"bool"}],"stateMutability":"view"},{"type":"function","name":"setTokenExternalMatchFeeRate","inputs":[{"name":"asset","type":"address","internalType":"address"},{"name":"fee","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"settleOfflineFee","inputs":[{"name":"statement","type":"tuple","internalType":"struct ValidOfflineFeeSettlementStatement","components":[{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"},{"name":"walletNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"updatedWalletCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"updatedWalletPublicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"noteCiphertext","type":"tuple","internalType":"struct ElGamalCiphertext","components":[{"name":"ephemeralKey","type":"tuple","internalType":"struct BabyJubJubPoint","components":[{"name":"x","type":"uint256","internalType":"BN254.ScalarField"},{"name":"y","type":"uint256","internalType":"BN254.ScalarField"}]},{"name":"ciphertext","type":"uint256[]","internalType":"BN254.ScalarField[]"}]},{"name":"noteCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"protocolKey","type":"tuple","internalType":"struct EncryptionKey","components":[{"name":"point","type":"tuple","internalType":"struct BabyJubJubPoint","components":[{"name":"x","type":"uint256","internalType":"BN254.ScalarField"},{"name":"y","type":"uint256","internalType":"BN254.ScalarField"}]}]},{"name":"isProtocolFee","type":"bool","internalType":"bool"}]},{"name":"proof","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}],"outputs":[],"stateMutability":"payable"},{"type":"function","name":"updateWallet","inputs":[{"name":"newSharesCommitmentSig","type":"bytes","internalType":"bytes"},{"name":"transferAuthorization","type":"tuple","internalType":"struct TransferAuthorization","components":[{"name":"permit2Nonce","type":"uint256","internalType":"uint256"},{"name":"permit2Deadline","type":"uint256","internalType":"uint256"},{"name":"permit2Signature","type":"bytes","internalType":"bytes"},{"name":"externalTransferSignature","type":"bytes","internalType":"bytes"}]},{"name":"statement","type":"tuple","internalType":"struct ValidWalletUpdateStatement","components":[{"name":"previousNullifier","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPrivateShareCommitment","type":"uint256","internalType":"BN254.ScalarField"},{"name":"newPublicShares","type":"uint256[]","internalType":"BN254.ScalarField[]"},{"name":"merkleRoot","type":"uint256","internalType":"BN254.ScalarField"},{"name":"externalTransfer","type":"tuple","internalType":"struct ExternalTransfer","components":[{"name":"account","type":"address","internalType":"address"},{"name":"mint","type":"address","internalType":"address"},{"name":"amount","type":"uint256","internalType":"uint256"},{"name":"transferType","type":"uint8","internalType":"enum TransferType"}]},{"name":"oldPkRoot","type":"tuple","internalType":"struct PublicRootKey","components":[{"name":"x","type":"uint256[2]","internalType":"BN254.ScalarField[2]"},{"name":"y","type":"uint256[2]","internalType":"BN254.ScalarField[2]"}]}]},{"name":"proof","type":"tuple","internalType":"struct PlonkProof","components":[{"name":"wire_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"z_comm","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"quotient_comms","type":"tuple[5]","internalType":"struct BN254.G1Point[5]","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"w_zeta_omega","type":"tuple","internalType":"struct BN254.G1Point","components":[{"name":"x","type":"uint256","internalType":"BN254.BaseField"},{"name":"y","type":"uint256","internalType":"BN254.BaseField"}]},{"name":"wire_evals","type":"uint256[5]","internalType":"BN254.ScalarField[5]"},{"name":"sigma_evals","type":"uint256[4]","internalType":"BN254.ScalarField[4]"},{"name":"z_bar","type":"uint256","internalType":"BN254.ScalarField"}]}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"verifier","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IVerifier"}],"stateMutability":"view"},{"type":"function","name":"weth","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IWETH9"}],"stateMutability":"view"},{"type":"event","name":"MerkleInsertion","inputs":[{"name":"index","type":"uint128","indexed":true,"internalType":"uint128"},{"name":"value","type":"uint256","indexed":true,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"MerkleOpeningNode","inputs":[{"name":"depth","type":"uint8","indexed":true,"internalType":"uint8"},{"name":"index","type":"uint128","indexed":true,"internalType":"uint128"},{"name":"new_value","type":"uint256","indexed":false,"internalType":"uint256"}],"anonymous":false},{"type":"event","name":"WalletUpdated","inputs":[{"name":"wallet_blinder_share","type":"uint256","indexed":true,"internalType":"uint256"}],"anonymous":false}],"bytecode":{"object":"0x","sourceMap":"","linkReferences":{}},"deployedBytecode":{"object":"0x","sourceMap":"","linkReferences":{}},"methodIdentifiers":{"createWallet((uint256,uint256[]),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":"7d68fb23","getMerkleRoot()":"49590657","getProtocolFeeKey()":"bf71e0cb","getTokenExternalMatchFeeRate(address)":"7d0d25c1","hasher()":"ed33639f","nullifierSpent(uint256)":"69aa8088","perTokenFeeOverrides(address)":"afe1c7f8","permit2()":"12261ee7","processAtomicMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":"16b2152c","processAtomicMatchSettleWithReceiver(address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":"7dfb7a35","processMalleableAtomicMatchSettle(uint256,address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,(uint256),uint256,uint256,uint8),((uint256),(uint256)),((uint256),(uint256)),uint256[],address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":"cc6a0875","processMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),(((uint256,uint256,uint256)),(uint256,uint256,uint256)),(uint256[],uint256[],(uint256,uint256,uint256),(uint256,uint256,uint256),uint256),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":"be117db7","protocolFeeKey()":"a6618e27","protocolFeeRate()":"58f85880","protocolFeeRecipient()":"64df049e","redeemFee(bytes,(uint256,uint256,uint256,uint256,uint256,uint256[],(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":"110c0df8","rootInHistory(uint256)":"2e310d1a","setTokenExternalMatchFeeRate(address,uint256)":"330d503c","settleOfflineFee((uint256,uint256,uint256,uint256[],((uint256,uint256),uint256[]),uint256,((uint256,uint256)),bool),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":"eaecfb5e","updateWallet(bytes,(uint256,uint256,bytes,bytes),(uint256,uint256,uint256[],uint256,(address,address,uint256,uint8),(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":"92874b06","verifier()":"2b7ac3f3","weth()":"3fc8cef3"},"rawMetadata":"{\"compiler\":{\"version\":\"0.8.28+commit.7893614a\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"index\",\"type\":\"uint128\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"MerkleInsertion\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint8\",\"name\":\"depth\",\"type\":\"uint8\"},{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"index\",\"type\":\"uint128\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"new_value\",\"type\":\"uint256\"}],\"name\":\"MerkleOpeningNode\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"wallet_blinder_share\",\"type\":\"uint256\"}],\"name\":\"WalletUpdated\",\"type\":\"event\"},{\"inputs\":[{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"privateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"publicShares\",\"type\":\"uint256[]\"}],\"internalType\":\"struct ValidWalletCreateStatement\",\"name\":\"statement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"proof\",\"type\":\"tuple\"}],\"name\":\"createWallet\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getMerkleRoot\",\"outputs\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getProtocolFeeKey\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BabyJubJubPoint\",\"name\":\"point\",\"type\":\"tuple\"}],\"internalType\":\"struct EncryptionKey\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"}],\"name\":\"getTokenExternalMatchFeeRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"hasher\",\"outputs\":[{\"internalType\":\"contract IHasher\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"nullifier\",\"type\":\"uint256\"}],\"name\":\"nullifierSpent\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"perTokenFeeOverrides\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"permit2\",\"outputs\":[{\"internalType\":\"contract IPermit2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"indices\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidCommitmentsStatement\",\"name\":\"validCommitmentsStatement\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"originalSharesNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newPrivateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"}],\"internalType\":\"struct ValidReblindStatement\",\"name\":\"validReblindStatement\",\"type\":\"tuple\"}],\"internalType\":\"struct PartyMatchPayload\",\"name\":\"internalPartyPayload\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"quoteMint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"baseMint\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"quoteAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"baseAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ExternalMatchDirection\",\"name\":\"direction\",\"type\":\"uint8\"}],\"internalType\":\"struct ExternalMatchResult\",\"name\":\"matchResult\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"relayerFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"protocolFee\",\"type\":\"uint256\"}],\"internalType\":\"struct FeeTake\",\"name\":\"externalPartyFees\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"internalPartyModifiedShares\",\"type\":\"uint256[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"internalPartySettlementIndices\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"protocolFeeRate\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"relayerFeeAddress\",\"type\":\"address\"}],\"internalType\":\"struct ValidMatchSettleAtomicStatement\",\"name\":\"matchSettleStatement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validCommitments\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validReblind\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validMatchSettleAtomic\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchAtomicProofs\",\"name\":\"proofs\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validReblindCommitments\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validCommitmentsMatchSettleAtomic\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchAtomicLinkingProofs\",\"name\":\"linkingProofs\",\"type\":\"tuple\"}],\"name\":\"processAtomicMatchSettle\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"indices\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidCommitmentsStatement\",\"name\":\"validCommitmentsStatement\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"originalSharesNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newPrivateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"}],\"internalType\":\"struct ValidReblindStatement\",\"name\":\"validReblindStatement\",\"type\":\"tuple\"}],\"internalType\":\"struct PartyMatchPayload\",\"name\":\"internalPartyPayload\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"quoteMint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"baseMint\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"quoteAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"baseAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ExternalMatchDirection\",\"name\":\"direction\",\"type\":\"uint8\"}],\"internalType\":\"struct ExternalMatchResult\",\"name\":\"matchResult\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"relayerFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"protocolFee\",\"type\":\"uint256\"}],\"internalType\":\"struct FeeTake\",\"name\":\"externalPartyFees\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"internalPartyModifiedShares\",\"type\":\"uint256[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"internalPartySettlementIndices\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"protocolFeeRate\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"relayerFeeAddress\",\"type\":\"address\"}],\"internalType\":\"struct ValidMatchSettleAtomicStatement\",\"name\":\"matchSettleStatement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validCommitments\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validReblind\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validMatchSettleAtomic\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchAtomicProofs\",\"name\":\"proofs\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validReblindCommitments\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validCommitmentsMatchSettleAtomic\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchAtomicLinkingProofs\",\"name\":\"linkingProofs\",\"type\":\"tuple\"}],\"name\":\"processAtomicMatchSettleWithReceiver\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"baseAmount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"indices\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidCommitmentsStatement\",\"name\":\"validCommitmentsStatement\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"originalSharesNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newPrivateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"}],\"internalType\":\"struct ValidReblindStatement\",\"name\":\"validReblindStatement\",\"type\":\"tuple\"}],\"internalType\":\"struct PartyMatchPayload\",\"name\":\"internalPartyPayload\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"quoteMint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"baseMint\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"repr\",\"type\":\"uint256\"}],\"internalType\":\"struct FixedPoint\",\"name\":\"price\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minBaseAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxBaseAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ExternalMatchDirection\",\"name\":\"direction\",\"type\":\"uint8\"}],\"internalType\":\"struct BoundedMatchResult\",\"name\":\"matchResult\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"repr\",\"type\":\"uint256\"}],\"internalType\":\"struct FixedPoint\",\"name\":\"relayerFeeRate\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"repr\",\"type\":\"uint256\"}],\"internalType\":\"struct FixedPoint\",\"name\":\"protocolFeeRate\",\"type\":\"tuple\"}],\"internalType\":\"struct FeeTakeRate\",\"name\":\"externalFeeRates\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"repr\",\"type\":\"uint256\"}],\"internalType\":\"struct FixedPoint\",\"name\":\"relayerFeeRate\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"repr\",\"type\":\"uint256\"}],\"internalType\":\"struct FixedPoint\",\"name\":\"protocolFeeRate\",\"type\":\"tuple\"}],\"internalType\":\"struct FeeTakeRate\",\"name\":\"internalFeeRates\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"internalPartyPublicShares\",\"type\":\"uint256[]\"},{\"internalType\":\"address\",\"name\":\"relayerFeeAddress\",\"type\":\"address\"}],\"internalType\":\"struct ValidMalleableMatchSettleAtomicStatement\",\"name\":\"matchSettleStatement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validCommitments\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validReblind\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validMalleableMatchSettleAtomic\",\"type\":\"tuple\"}],\"internalType\":\"struct MalleableMatchAtomicProofs\",\"name\":\"proofs\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validReblindCommitments\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validCommitmentsMatchSettleAtomic\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchAtomicLinkingProofs\",\"name\":\"linkingProofs\",\"type\":\"tuple\"}],\"name\":\"processMalleableAtomicMatchSettle\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"indices\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidCommitmentsStatement\",\"name\":\"validCommitmentsStatement\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"originalSharesNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newPrivateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"}],\"internalType\":\"struct ValidReblindStatement\",\"name\":\"validReblindStatement\",\"type\":\"tuple\"}],\"internalType\":\"struct PartyMatchPayload\",\"name\":\"party0MatchPayload\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"indices\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidCommitmentsStatement\",\"name\":\"validCommitmentsStatement\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"originalSharesNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newPrivateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"}],\"internalType\":\"struct ValidReblindStatement\",\"name\":\"validReblindStatement\",\"type\":\"tuple\"}],\"internalType\":\"struct PartyMatchPayload\",\"name\":\"party1MatchPayload\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"firstPartyPublicShares\",\"type\":\"uint256[]\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"secondPartyPublicShares\",\"type\":\"uint256[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"firstPartySettlementIndices\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"balanceSend\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balanceReceive\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"order\",\"type\":\"uint256\"}],\"internalType\":\"struct OrderSettlementIndices\",\"name\":\"secondPartySettlementIndices\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"protocolFeeRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ValidMatchSettleStatement\",\"name\":\"matchSettleStatement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validCommitments0\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validReblind0\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validCommitments1\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validReblind1\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"validMatchSettle\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchProofs\",\"name\":\"proofs\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validReblindCommitments0\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validCommitmentsMatchSettle0\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validReblindCommitments1\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_quotient_poly_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"linking_poly_opening\",\"type\":\"tuple\"}],\"internalType\":\"struct LinkingProof\",\"name\":\"validCommitmentsMatchSettle1\",\"type\":\"tuple\"}],\"internalType\":\"struct MatchLinkingProofs\",\"name\":\"linkingProofs\",\"type\":\"tuple\"}],\"name\":\"processMatchSettle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"protocolFeeKey\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BabyJubJubPoint\",\"name\":\"point\",\"type\":\"tuple\"}],\"internalType\":\"struct EncryptionKey\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"protocolFeeRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"protocolFeeRecipient\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"recipientCommitmentSig\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"walletRoot\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"noteRoot\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"walletNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"noteNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newWalletCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"newWalletPublicShares\",\"type\":\"uint256[]\"},{\"components\":[{\"internalType\":\"BN254.ScalarField[2]\",\"name\":\"x\",\"type\":\"uint256[2]\"},{\"internalType\":\"BN254.ScalarField[2]\",\"name\":\"y\",\"type\":\"uint256[2]\"}],\"internalType\":\"struct PublicRootKey\",\"name\":\"walletRootKey\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidFeeRedemptionStatement\",\"name\":\"statement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"proof\",\"type\":\"tuple\"}],\"name\":\"redeemFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"root\",\"type\":\"uint256\"}],\"name\":\"rootInHistory\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"asset\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"fee\",\"type\":\"uint256\"}],\"name\":\"setTokenExternalMatchFeeRate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"walletNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"updatedWalletCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"updatedWalletPublicShares\",\"type\":\"uint256[]\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BabyJubJubPoint\",\"name\":\"ephemeralKey\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"ciphertext\",\"type\":\"uint256[]\"}],\"internalType\":\"struct ElGamalCiphertext\",\"name\":\"noteCiphertext\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"noteCommitment\",\"type\":\"uint256\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BabyJubJubPoint\",\"name\":\"point\",\"type\":\"tuple\"}],\"internalType\":\"struct EncryptionKey\",\"name\":\"protocolKey\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"isProtocolFee\",\"type\":\"bool\"}],\"internalType\":\"struct ValidOfflineFeeSettlementStatement\",\"name\":\"statement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"proof\",\"type\":\"tuple\"}],\"name\":\"settleOfflineFee\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"newSharesCommitmentSig\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"permit2Nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"permit2Deadline\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"permit2Signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"externalTransferSignature\",\"type\":\"bytes\"}],\"internalType\":\"struct TransferAuthorization\",\"name\":\"transferAuthorization\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField\",\"name\":\"previousNullifier\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"newPrivateShareCommitment\",\"type\":\"uint256\"},{\"internalType\":\"BN254.ScalarField[]\",\"name\":\"newPublicShares\",\"type\":\"uint256[]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"merkleRoot\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"mint\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"enum TransferType\",\"name\":\"transferType\",\"type\":\"uint8\"}],\"internalType\":\"struct ExternalTransfer\",\"name\":\"externalTransfer\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.ScalarField[2]\",\"name\":\"x\",\"type\":\"uint256[2]\"},{\"internalType\":\"BN254.ScalarField[2]\",\"name\":\"y\",\"type\":\"uint256[2]\"}],\"internalType\":\"struct PublicRootKey\",\"name\":\"oldPkRoot\",\"type\":\"tuple\"}],\"internalType\":\"struct ValidWalletUpdateStatement\",\"name\":\"statement\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"wire_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"z_comm\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point[5]\",\"name\":\"quotient_comms\",\"type\":\"tuple[5]\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"BN254.BaseField\",\"name\":\"x\",\"type\":\"uint256\"},{\"internalType\":\"BN254.BaseField\",\"name\":\"y\",\"type\":\"uint256\"}],\"internalType\":\"struct BN254.G1Point\",\"name\":\"w_zeta_omega\",\"type\":\"tuple\"},{\"internalType\":\"BN254.ScalarField[5]\",\"name\":\"wire_evals\",\"type\":\"uint256[5]\"},{\"internalType\":\"BN254.ScalarField[4]\",\"name\":\"sigma_evals\",\"type\":\"uint256[4]\"},{\"internalType\":\"BN254.ScalarField\",\"name\":\"z_bar\",\"type\":\"uint256\"}],\"internalType\":\"struct PlonkProof\",\"name\":\"proof\",\"type\":\"tuple\"}],\"name\":\"updateWallet\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"verifier\",\"outputs\":[{\"internalType\":\"contract IVerifier\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"weth\",\"outputs\":[{\"internalType\":\"contract IWETH9\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"events\":{\"MerkleInsertion(uint128,uint256)\":{\"params\":{\"index\":\"The leaf index\",\"value\":\"The value of the leaf\"}},\"MerkleOpeningNode(uint8,uint128,uint256)\":{\"params\":{\"depth\":\"The depth at which the node is updated\",\"index\":\"The index of the node in the Merkle tree\",\"new_value\":\"The new value of the node\"}},\"WalletUpdated(uint256)\":{\"params\":{\"wallet_blinder_share\":\"The public blinder share of the wallet, used for indexing\"}}},\"kind\":\"dev\",\"methods\":{\"createWallet((uint256,uint256[]),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"params\":{\"proof\":\"The proof of `VALID WALLET CREATE`\",\"statement\":\"The statement to verify\"}},\"getMerkleRoot()\":{\"returns\":{\"_0\":\"The current Merkle root\"}},\"getProtocolFeeKey()\":{\"returns\":{\"_0\":\"The public encryption key for the protocol's fees\"}},\"getTokenExternalMatchFeeRate(address)\":{\"details\":\"This fee only applies to external matches\",\"params\":{\"asset\":\"The asset to get the protocol fee rate for\"},\"returns\":{\"_0\":\"The protocol fee rate for the asset\"}},\"nullifierSpent(uint256)\":{\"params\":{\"nullifier\":\"The nullifier to check\"},\"returns\":{\"_0\":\"Whether the nullifier has been spent\"}},\"processAtomicMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"details\":\"An internal party is one with state committed into the darkpool, whilean external party provides liquidity to the pool during thetransaction in which this method is calledThe receiver of the match settlement is the sender of the transaction\",\"params\":{\"internalPartyPayload\":\"The validity proofs for the internal party\",\"linkingProofs\":\"The proof-linking arguments for the match\",\"matchSettleStatement\":\"The statement (public inputs) of `VALID MATCH SETTLE`\",\"proofs\":\"The proofs for the match\"}},\"processAtomicMatchSettleWithReceiver(address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"details\":\"The receiver will receive the buy side token amount implied by the matchnet of fees by the relayer and protocol\",\"params\":{\"internalPartyPayload\":\"The validity proofs for the internal party\",\"linkingProofs\":\"The proof-linking arguments for the match\",\"matchSettleStatement\":\"The statement (public inputs) of `VALID MATCH SETTLE`\",\"proofs\":\"The proofs for the match\",\"receiver\":\"The address that will receive the buy side token amount implied by the match\"}},\"processMalleableAtomicMatchSettle(uint256,address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,(uint256),uint256,uint256,uint8),((uint256),(uint256)),((uint256),(uint256)),uint256[],address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"details\":\"This is a variant of `processAtomicMatchSettle` that allows the match amount to be determinedafter the proof is generated. This is done by the prover constraining a valid range for the matchamount, allowing the tx sender to choose any value in this range.The darkpool then uses the price specified in the statement to determine the quote amount and feesfor the match, then settles the obligations to both the internal and external parties\",\"params\":{\"baseAmount\":\"The base amount of the match, resolving in between the bounds\",\"internalPartyPayload\":\"The validity proofs for the internal party\",\"linkingProofs\":\"The proof-linking arguments for the match\",\"matchSettleStatement\":\"The statement (public inputs) of `VALID MATCH SETTLE`\",\"proofs\":\"The proofs for the match\",\"receiver\":\"The address that will receive the buy side token amount for the external party\"}},\"processMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),(((uint256,uint256,uint256)),(uint256,uint256,uint256)),(uint256[],uint256[],(uint256,uint256,uint256),(uint256,uint256,uint256),uint256),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"params\":{\"matchSettleStatement\":\"The statement of `VALID MATCH SETTLE`\",\"party0MatchPayload\":\"The validity proofs payload for the first party\",\"party1MatchPayload\":\"The validity proofs payload for the second party\",\"proofs\":\"The proofs for the match, including two sets of validity proofs and a settlement proof\"}},\"redeemFee(bytes,(uint256,uint256,uint256,uint256,uint256,uint256[],(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"params\":{\"proof\":\"The proof of `VALID FEE REDEMPTION`\",\"statement\":\"The statement of `VALID FEE REDEMPTION`\"}},\"rootInHistory(uint256)\":{\"params\":{\"root\":\"The root to check\"},\"returns\":{\"_0\":\"Whether the root is in the history\"}},\"setTokenExternalMatchFeeRate(address,uint256)\":{\"details\":\"of a real number between 0 and 1. To convert to its floating point representation,divide by the fixed point precision, i.e. `fee = assetFeeRate / FIXED_POINT_PRECISION`.\",\"params\":{\"asset\":\"The asset to set the protocol fee rate for\",\"fee\":\"The protocol fee rate to set. This is a fixed point representation\"}},\"settleOfflineFee((uint256,uint256,uint256,uint256[],((uint256,uint256),uint256[]),uint256,((uint256,uint256)),bool),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"details\":\"Instead of updating the recipient's wallet, a `Note` is created that the recipient may later redeem\",\"params\":{\"proof\":\"The proof of `VALID OFFLINE FEE SETTLEMENT`\",\"statement\":\"The statement of `VALID OFFLINE FEE SETTLEMENT`\"}},\"updateWallet(bytes,(uint256,uint256,bytes,bytes),(uint256,uint256,uint256[],uint256,(address,address,uint256,uint8),(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"params\":{\"newSharesCommitmentSig\":\"The signature of the new wallet shares commitment by the old wallet's root key\",\"proof\":\"The proof of `VALID WALLET UPDATE`\",\"statement\":\"The statement to verify\"}}},\"version\":1},\"userdoc\":{\"events\":{\"MerkleInsertion(uint128,uint256)\":{\"notice\":\"Emitted when a Merkle leaf is inserted into the tree\"},\"MerkleOpeningNode(uint8,uint128,uint256)\":{\"notice\":\"Emitted when an internal Merkle node is updated\"},\"WalletUpdated(uint256)\":{\"notice\":\"Emitted when a wallet update is performed\"}},\"kind\":\"user\",\"methods\":{\"createWallet((uint256,uint256[]),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"notice\":\"Create a wallet in the darkpool\"},\"getMerkleRoot()\":{\"notice\":\"Get the current Merkle root\"},\"getProtocolFeeKey()\":{\"notice\":\"Get the public encryption key for the protocol's fees\"},\"getTokenExternalMatchFeeRate(address)\":{\"notice\":\"Get the protocol fee rate for a given asset\"},\"hasher()\":{\"notice\":\"The hasher for the darkpool\"},\"nullifierSpent(uint256)\":{\"notice\":\"Check whether a nullifier has been spent\"},\"perTokenFeeOverrides(address)\":{\"notice\":\"A per-asset fee override for the darkpool\"},\"permit2()\":{\"notice\":\"The Permit2 contract instance for handling deposits\"},\"processAtomicMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"notice\":\"Process and atomic match settlement between two parties; one internal and one external\"},\"processAtomicMatchSettleWithReceiver(address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"notice\":\"Process an atomic match with a non-sender receiver specified\"},\"processMalleableAtomicMatchSettle(uint256,address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,(uint256),uint256,uint256,uint8),((uint256),(uint256)),((uint256),(uint256)),uint256[],address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"notice\":\"Process a malleable match settlement between two parties\"},\"processMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),(((uint256,uint256,uint256)),(uint256,uint256,uint256)),(uint256[],uint256[],(uint256,uint256,uint256),(uint256,uint256,uint256),uint256),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))\":{\"notice\":\"Settle a match in the darkpool\"},\"protocolFeeKey()\":{\"notice\":\"The public encryption key for the protocol's fees\"},\"protocolFeeRate()\":{\"notice\":\"The protocol fee rate for the darkpool\"},\"protocolFeeRecipient()\":{\"notice\":\"The address at which external parties pay protocol fees\"},\"redeemFee(bytes,(uint256,uint256,uint256,uint256,uint256,uint256[],(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"notice\":\"Redeem a fee that has been paid offline into a wallet\"},\"rootInHistory(uint256)\":{\"notice\":\"Check whether a root is in the Merkle root history\"},\"setTokenExternalMatchFeeRate(address,uint256)\":{\"notice\":\"Set the protocol fee rate for a given asset\"},\"settleOfflineFee((uint256,uint256,uint256,uint256[],((uint256,uint256),uint256[]),uint256,((uint256,uint256)),bool),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"notice\":\"Settle a fee due to the protocol or a relayer offline, i.e. without updating the recipient's wallet\"},\"updateWallet(bytes,(uint256,uint256,bytes,bytes),(uint256,uint256,uint256[],uint256,(address,address,uint256,uint8),(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))\":{\"notice\":\"Update a wallet in the darkpool\"},\"verifier()\":{\"notice\":\"The verifier for the darkpool\"},\"weth()\":{\"notice\":\"The WETH9 contract instance used for depositing/withdrawing native tokens\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/libraries/interfaces/IDarkpool.sol\":\"IDarkpool\"},\"evmVersion\":\"cancun\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/\",\":ds-test/=lib/forge-std/lib/ds-test/src/\",\":erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/\",\":forge-gas-snapshot/=lib/permit2/lib/forge-gas-snapshot/src/\",\":forge-std/=lib/forge-std/src/\",\":foundry-huff/=lib/foundry-huff/src/\",\":halmos-cheatcodes/=lib/openzeppelin-contracts/lib/halmos-cheatcodes/src/\",\":openzeppelin-contracts/=lib/openzeppelin-contracts/\",\":oz-contracts/=lib/openzeppelin-contracts/contracts/\",\":permit2-test/=lib/permit2/test/\",\":permit2/=lib/permit2/src/\",\":renegade-lib/=src/libraries/\",\":renegade/=src/\",\":solidity-bn254/=lib/solidity-bn254/src/\",\":solidity-stringutils/=lib/foundry-huff/lib/solidity-stringutils/\",\":solmate/=lib/permit2/lib/solmate/\",\":stringutils/=lib/foundry-huff/lib/solidity-stringutils/\"],\"viaIR\":true},\"sources\":{\"lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol\":{\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://df6f0c459663c9858b6cba2cda1d14a7d05a985bed6d2de72bd8e78c25ee79db\",\"dweb:/ipfs/QmeTTxZ7qVk9rjEv2R4CpCwdf8UMCcRqDNMvzNxHc3Fnn9\"]},\"lib/openzeppelin-contracts/contracts/utils/Panic.sol\":{\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a\",\"dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG\"]},\"lib/openzeppelin-contracts/contracts/utils/math/Math.sol\":{\"keccak256\":\"0xa00be322d7db5786750ce0ac7e2f5b633ac30a5ed5fa1ced1e74acfc19acecea\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6c84e822f87cbdc4082533b626667b6928715bb2b1e8e7eb96954cebb9e38c8d\",\"dweb:/ipfs/QmZmy9dgxLTerBAQDuuHqbL6EpgRxddqgv5KmwpXYVbKz1\"]},\"lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol\":{\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8\",\"dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy\"]},\"lib/permit2/src/interfaces/IAllowanceTransfer.sol\":{\"keccak256\":\"0x37f0ac203b6ef605c9533e1a739477e8e9dcea90710b40e645a367f8a21ace29\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e0104d72aeaec1cd66cc232e7de7b7ead08608efcc179491b8a66387614670b0\",\"dweb:/ipfs/QmfAZDyuNC9FXXbnJUwqHNwmAK6uRrXxtWEytLsxjskPsN\"]},\"lib/permit2/src/interfaces/IEIP712.sol\":{\"keccak256\":\"0xfdccf2b9639070803cd0e4198427fb0df3cc452ca59bd3b8a0d957a9a4254138\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f7c936ac42ce89e827db905a1544397f8bdf46db34cdb6aa1b90dea42fdb4c72\",\"dweb:/ipfs/QmVgurxo1N31qZqkPBirw9Z7S9tLYmv6jSwQp8R8ur2cBk\"]},\"lib/permit2/src/interfaces/IPermit2.sol\":{\"keccak256\":\"0xaa631cc9f53e699301d94233007110a345e6779011def484e8dd97b8fe0af771\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://fc0502cf19c9c18f320a3001201e89e350393b75837f6b7971de18b2de06f30d\",\"dweb:/ipfs/QmT9SfhdJ7VJNNrf94g4H5usyi7ShqWGx7Cqsz9jZTjX96\"]},\"lib/permit2/src/interfaces/ISignatureTransfer.sol\":{\"keccak256\":\"0xe6df9966f8841dc3958ee86169c89de97e7f614c81c28b9dc947b12d732df64e\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://3d4eafdee7f48c3be8350a94eb6edd0bfb2af2c105df65787a77174f356c0317\",\"dweb:/ipfs/QmY1j2adeeAhNpn6cUuthemxGCdLXHTfyMh9yTKsY4mZ2d\"]},\"lib/solidity-bn254/src/BN254.sol\":{\"keccak256\":\"0x2ced33c87eb8292d836fbaba94c31951737cc17be2a60f4a866d326b5365551e\",\"license\":\"GPL-3.0-or-later\",\"urls\":[\"bzz-raw://d9003a3265c76bad130114593623709d0ca2c61c8eab0d9328cda6b4f31f8c6c\",\"dweb:/ipfs/QmV9RR8fTQFYcDUwmCpMndNW9ioc1g9fbNdN9Hn1ySqKWb\"]},\"lib/solidity-bn254/src/Utils.sol\":{\"keccak256\":\"0x7aa0d7ff8ac27a50f8ceac860c11b17fb103ccd92034c220d040f4a8a9691cbf\",\"license\":\"GPL-3.0-or-later\",\"urls\":[\"bzz-raw://706e1299d213e627ff62838f63a10813a24335ea4969a7eee9f8854fe35f2d64\",\"dweb:/ipfs/QmVGMSUiub16V2MFcVDQupF1JmhPQ4R83iehqCNLLy3eKG\"]},\"src/libraries/darkpool/Constants.sol\":{\"keccak256\":\"0x840121ae99751a27befd7265d6969b621f71455e3a05f2bd957e433361bc9b78\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ff3ff74f7b5a5082680c421cd7c18703ab79fc289203d3483d7faabdd09a237f\",\"dweb:/ipfs/QmRdTmqnKSGJCLZDDN1Bw9qDsbAx5nHgbTc4bUxtLnLpdz\"]},\"src/libraries/darkpool/PublicInputs.sol\":{\"keccak256\":\"0x55596285e549f10cdaece9da196c02ca994adccba918e867597985c4c687903f\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://cc4e4fbeab9970b44abea3454d44d9e38c4dbd470af480263a81c9acc289735b\",\"dweb:/ipfs/QmXpUc3K3WtqzmYL8Mbyf3yfWWtkt7iNap2ZBfVxHG5V2Q\"]},\"src/libraries/darkpool/types/Ciphertext.sol\":{\"keccak256\":\"0x79751e669b992c5ee5a3d40658e0be2d33b14326b72a398e63c5a1dfc947e685\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://5fa5469c7601bc80f5523ab3d9855e84164321dd6650c26a6704eb737144b656\",\"dweb:/ipfs/QmSNhFtPwSYZoqyu4EXqUyfuzm8eKYA57sZFrna1VBSjWs\"]},\"src/libraries/darkpool/types/Fees.sol\":{\"keccak256\":\"0x7c04b215697277010ce10e1a2e1608639625b64bbf103167ba98badc88114d7e\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://eb20ac8c1ebc7cbfd0fe18dd447e5b14a988637ef964f897863ce248f9d0bde4\",\"dweb:/ipfs/QmPLtvSNMMeHcWUos3AxpGJstgwASwHMPUsuF19pU6ExDE\"]},\"src/libraries/darkpool/types/Keychain.sol\":{\"keccak256\":\"0xd2e6dd4753e49ef86d0cad42e24f421560dd4b4df23b43b77a9d65b796ffdbe2\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://535085e6f29411e91bd76f91afcc62b9051b264d307c2a5b8e8c95f29d67f24f\",\"dweb:/ipfs/QmTzDSsbxpf6ZiPzmyjiFweABHRWkXYbSWA7zZbRHUdUVZ\"]},\"src/libraries/darkpool/types/Settlement.sol\":{\"keccak256\":\"0x95d58c0d89528101c29337fd26a563c6554a085913b33c26f7f4ed43a549476c\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://5b9efd44f48e7223431d0c3770f360b7c6557f56a9ed418fd77b1d1961ded44f\",\"dweb:/ipfs/QmNtxof8F9duFCv66uHM49WumRie17h3e7qJqWXiMxJe51\"]},\"src/libraries/darkpool/types/Transfers.sol\":{\"keccak256\":\"0x9333ba611417507c6517cc67dd91c552e663a7ce8988e3dd704e0e8102f45071\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://e60081668353bd2f6fc9a40178a718ae88fffd730ad6ef0a6647117351764d38\",\"dweb:/ipfs/QmXB1E8UYMHsWkvYiswCnBhYkCLaGUqsqVL7xaVopCUHNB\"]},\"src/libraries/darkpool/types/TypesLib.sol\":{\"keccak256\":\"0x68887b160040cd0929b3db18f90d44838ade4380d51ee660524690cf136decf2\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://0e80a166c85b9fd3d3dc8bd9bddb54221b766211c801ce021d6c6eabd79e1c5a\",\"dweb:/ipfs/QmdzqaQBrLW6C4qvKakKGUHPj3EzfUg15nucZc6VyrE1SW\"]},\"src/libraries/darkpool/types/Wallet.sol\":{\"keccak256\":\"0xaf0eaba75e6c68b6368e346a90767cd58b77dfb94a4a1e7366b8c33cd0cddb63\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://3b0c5fee21af2ff5c5721461c7133edcb09173c696c476b4a7165025f10bc485\",\"dweb:/ipfs/QmTcotbrAc7fEGi25dJGeP3wYmX3THciikcQeRn3CUoF1C\"]},\"src/libraries/interfaces/IDarkpool.sol\":{\"keccak256\":\"0x4eb753e30b4b9aa62b748317df5f04cf53217e704ff0f0d455f8986c16209451\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://a30e383a4d5dbbc8c5f7fe8ef2c7085096d30073524336f3e9f0f0713b0b785f\",\"dweb:/ipfs/QmT1FjhJbZEsi4Cbsjg3AAngjHgpVWWuVaNoBy7yQpbxBK\"]},\"src/libraries/interfaces/IHasher.sol\":{\"keccak256\":\"0x398864a227ae6435a6a466c8e9469def8cf9d91de1ae6a638c97f512576a34c5\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://244515ebe78503113a482e261cf8ef8d3b7d4be80369dbaec92c58dd4c866309\",\"dweb:/ipfs/QmV1NuXKe3VVjL5HoaRwZQtPmSMNssxe3APyN7beM5pGJh\"]},\"src/libraries/interfaces/IVerifier.sol\":{\"keccak256\":\"0xfabb9f913ab4a3a4a9150b6c1675368c038babc3dc725f4d9867d90b146c7cdc\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://782b2c3c84deba435b8ddaa871b3a6221a1a78ff4c7ad238defc1a21347d262f\",\"dweb:/ipfs/QmUupqL6Cfb69KhvYWt6jGnRLz55KUpkmC1nTiRRFWyWKV\"]},\"src/libraries/interfaces/IWETH9.sol\":{\"keccak256\":\"0x05a109500d93a34a4046bd644c19017362795352656d123eb3bf5ce26c7a26c6\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://bcc3d5f2251ce33455959caf39fc19209b7a355916c47378bd4e7f4b0ee31f35\",\"dweb:/ipfs/QmaS2K29tTQbF3zWNses6KCuwqQUStwQJ8JMcsHJUi5RkF\"]},\"src/libraries/verifier/BN254Helpers.sol\":{\"keccak256\":\"0xde01afe43d75609756857d8681a9af9b8c2e96d05c59408a4f3b369676b190b5\",\"license\":\"Apache-2.0\",\"urls\":[\"bzz-raw://2ed17530e325ba109e73b25ec3d177ead9dea2fff4b48c680522c1d41531a623\",\"dweb:/ipfs/QmaCeDDWs2HFN8evWjaWmGF7DHcbMvFxowxwiyyBD3amzy\"]},\"src/libraries/verifier/Types.sol\":{\"keccak256\":\"0x35403540cf17679654c73b32e58afab852fba06118896f1c1b216ea984444210\",\"license\":\"Apache-2.0\",\"urls\":[\"bzz-raw://86458d287395956c743f514b8671b4e83929abedcc772e7ff7172c9b1accf3dc\",\"dweb:/ipfs/Qme5WC3HRQrkJqjqWwnYThtpcYdp1RHxAhH9RrwWNhbTPd\"]}},\"version\":1}","metadata":{"compiler":{"version":"0.8.28+commit.7893614a"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"uint128","name":"index","type":"uint128","indexed":true},{"internalType":"uint256","name":"value","type":"uint256","indexed":true}],"type":"event","name":"MerkleInsertion","anonymous":false},{"inputs":[{"internalType":"uint8","name":"depth","type":"uint8","indexed":true},{"internalType":"uint128","name":"index","type":"uint128","indexed":true},{"internalType":"uint256","name":"new_value","type":"uint256","indexed":false}],"type":"event","name":"MerkleOpeningNode","anonymous":false},{"inputs":[{"internalType":"uint256","name":"wallet_blinder_share","type":"uint256","indexed":true}],"type":"event","name":"WalletUpdated","anonymous":false},{"inputs":[{"internalType":"struct ValidWalletCreateStatement","name":"statement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"privateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField[]","name":"publicShares","type":"uint256[]"}]},{"internalType":"struct PlonkProof","name":"proof","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}],"stateMutability":"nonpayable","type":"function","name":"createWallet"},{"inputs":[],"stateMutability":"view","type":"function","name":"getMerkleRoot","outputs":[{"internalType":"BN254.ScalarField","name":"","type":"uint256"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"getProtocolFeeKey","outputs":[{"internalType":"struct EncryptionKey","name":"","type":"tuple","components":[{"internalType":"struct BabyJubJubPoint","name":"point","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"x","type":"uint256"},{"internalType":"BN254.ScalarField","name":"y","type":"uint256"}]}]}]},{"inputs":[{"internalType":"address","name":"asset","type":"address"}],"stateMutability":"view","type":"function","name":"getTokenExternalMatchFeeRate","outputs":[{"internalType":"uint256","name":"","type":"uint256"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"hasher","outputs":[{"internalType":"contract IHasher","name":"","type":"address"}]},{"inputs":[{"internalType":"BN254.ScalarField","name":"nullifier","type":"uint256"}],"stateMutability":"view","type":"function","name":"nullifierSpent","outputs":[{"internalType":"bool","name":"","type":"bool"}]},{"inputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function","name":"perTokenFeeOverrides","outputs":[{"internalType":"uint256","name":"","type":"uint256"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"permit2","outputs":[{"internalType":"contract IPermit2","name":"","type":"address"}]},{"inputs":[{"internalType":"struct PartyMatchPayload","name":"internalPartyPayload","type":"tuple","components":[{"internalType":"struct ValidCommitmentsStatement","name":"validCommitmentsStatement","type":"tuple","components":[{"internalType":"struct OrderSettlementIndices","name":"indices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]}]},{"internalType":"struct ValidReblindStatement","name":"validReblindStatement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"originalSharesNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newPrivateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"}]}]},{"internalType":"struct ValidMatchSettleAtomicStatement","name":"matchSettleStatement","type":"tuple","components":[{"internalType":"struct ExternalMatchResult","name":"matchResult","type":"tuple","components":[{"internalType":"address","name":"quoteMint","type":"address"},{"internalType":"address","name":"baseMint","type":"address"},{"internalType":"uint256","name":"quoteAmount","type":"uint256"},{"internalType":"uint256","name":"baseAmount","type":"uint256"},{"internalType":"enum ExternalMatchDirection","name":"direction","type":"uint8"}]},{"internalType":"struct FeeTake","name":"externalPartyFees","type":"tuple","components":[{"internalType":"uint256","name":"relayerFee","type":"uint256"},{"internalType":"uint256","name":"protocolFee","type":"uint256"}]},{"internalType":"BN254.ScalarField[]","name":"internalPartyModifiedShares","type":"uint256[]"},{"internalType":"struct OrderSettlementIndices","name":"internalPartySettlementIndices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]},{"internalType":"uint256","name":"protocolFeeRate","type":"uint256"},{"internalType":"address","name":"relayerFeeAddress","type":"address"}]},{"internalType":"struct MatchAtomicProofs","name":"proofs","type":"tuple","components":[{"internalType":"struct PlonkProof","name":"validCommitments","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validReblind","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validMatchSettleAtomic","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}]},{"internalType":"struct MatchAtomicLinkingProofs","name":"linkingProofs","type":"tuple","components":[{"internalType":"struct LinkingProof","name":"validReblindCommitments","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]},{"internalType":"struct LinkingProof","name":"validCommitmentsMatchSettleAtomic","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]}]}],"stateMutability":"payable","type":"function","name":"processAtomicMatchSettle"},{"inputs":[{"internalType":"address","name":"receiver","type":"address"},{"internalType":"struct PartyMatchPayload","name":"internalPartyPayload","type":"tuple","components":[{"internalType":"struct ValidCommitmentsStatement","name":"validCommitmentsStatement","type":"tuple","components":[{"internalType":"struct OrderSettlementIndices","name":"indices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]}]},{"internalType":"struct ValidReblindStatement","name":"validReblindStatement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"originalSharesNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newPrivateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"}]}]},{"internalType":"struct ValidMatchSettleAtomicStatement","name":"matchSettleStatement","type":"tuple","components":[{"internalType":"struct ExternalMatchResult","name":"matchResult","type":"tuple","components":[{"internalType":"address","name":"quoteMint","type":"address"},{"internalType":"address","name":"baseMint","type":"address"},{"internalType":"uint256","name":"quoteAmount","type":"uint256"},{"internalType":"uint256","name":"baseAmount","type":"uint256"},{"internalType":"enum ExternalMatchDirection","name":"direction","type":"uint8"}]},{"internalType":"struct FeeTake","name":"externalPartyFees","type":"tuple","components":[{"internalType":"uint256","name":"relayerFee","type":"uint256"},{"internalType":"uint256","name":"protocolFee","type":"uint256"}]},{"internalType":"BN254.ScalarField[]","name":"internalPartyModifiedShares","type":"uint256[]"},{"internalType":"struct OrderSettlementIndices","name":"internalPartySettlementIndices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]},{"internalType":"uint256","name":"protocolFeeRate","type":"uint256"},{"internalType":"address","name":"relayerFeeAddress","type":"address"}]},{"internalType":"struct MatchAtomicProofs","name":"proofs","type":"tuple","components":[{"internalType":"struct PlonkProof","name":"validCommitments","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validReblind","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validMatchSettleAtomic","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}]},{"internalType":"struct MatchAtomicLinkingProofs","name":"linkingProofs","type":"tuple","components":[{"internalType":"struct LinkingProof","name":"validReblindCommitments","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]},{"internalType":"struct LinkingProof","name":"validCommitmentsMatchSettleAtomic","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]}]}],"stateMutability":"payable","type":"function","name":"processAtomicMatchSettleWithReceiver"},{"inputs":[{"internalType":"uint256","name":"baseAmount","type":"uint256"},{"internalType":"address","name":"receiver","type":"address"},{"internalType":"struct PartyMatchPayload","name":"internalPartyPayload","type":"tuple","components":[{"internalType":"struct ValidCommitmentsStatement","name":"validCommitmentsStatement","type":"tuple","components":[{"internalType":"struct OrderSettlementIndices","name":"indices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]}]},{"internalType":"struct ValidReblindStatement","name":"validReblindStatement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"originalSharesNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newPrivateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"}]}]},{"internalType":"struct ValidMalleableMatchSettleAtomicStatement","name":"matchSettleStatement","type":"tuple","components":[{"internalType":"struct BoundedMatchResult","name":"matchResult","type":"tuple","components":[{"internalType":"address","name":"quoteMint","type":"address"},{"internalType":"address","name":"baseMint","type":"address"},{"internalType":"struct FixedPoint","name":"price","type":"tuple","components":[{"internalType":"uint256","name":"repr","type":"uint256"}]},{"internalType":"uint256","name":"minBaseAmount","type":"uint256"},{"internalType":"uint256","name":"maxBaseAmount","type":"uint256"},{"internalType":"enum ExternalMatchDirection","name":"direction","type":"uint8"}]},{"internalType":"struct FeeTakeRate","name":"externalFeeRates","type":"tuple","components":[{"internalType":"struct FixedPoint","name":"relayerFeeRate","type":"tuple","components":[{"internalType":"uint256","name":"repr","type":"uint256"}]},{"internalType":"struct FixedPoint","name":"protocolFeeRate","type":"tuple","components":[{"internalType":"uint256","name":"repr","type":"uint256"}]}]},{"internalType":"struct FeeTakeRate","name":"internalFeeRates","type":"tuple","components":[{"internalType":"struct FixedPoint","name":"relayerFeeRate","type":"tuple","components":[{"internalType":"uint256","name":"repr","type":"uint256"}]},{"internalType":"struct FixedPoint","name":"protocolFeeRate","type":"tuple","components":[{"internalType":"uint256","name":"repr","type":"uint256"}]}]},{"internalType":"BN254.ScalarField[]","name":"internalPartyPublicShares","type":"uint256[]"},{"internalType":"address","name":"relayerFeeAddress","type":"address"}]},{"internalType":"struct MalleableMatchAtomicProofs","name":"proofs","type":"tuple","components":[{"internalType":"struct PlonkProof","name":"validCommitments","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validReblind","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validMalleableMatchSettleAtomic","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}]},{"internalType":"struct MatchAtomicLinkingProofs","name":"linkingProofs","type":"tuple","components":[{"internalType":"struct LinkingProof","name":"validReblindCommitments","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]},{"internalType":"struct LinkingProof","name":"validCommitmentsMatchSettleAtomic","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]}]}],"stateMutability":"payable","type":"function","name":"processMalleableAtomicMatchSettle"},{"inputs":[{"internalType":"struct PartyMatchPayload","name":"party0MatchPayload","type":"tuple","components":[{"internalType":"struct ValidCommitmentsStatement","name":"validCommitmentsStatement","type":"tuple","components":[{"internalType":"struct OrderSettlementIndices","name":"indices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]}]},{"internalType":"struct ValidReblindStatement","name":"validReblindStatement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"originalSharesNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newPrivateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"}]}]},{"internalType":"struct PartyMatchPayload","name":"party1MatchPayload","type":"tuple","components":[{"internalType":"struct ValidCommitmentsStatement","name":"validCommitmentsStatement","type":"tuple","components":[{"internalType":"struct OrderSettlementIndices","name":"indices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]}]},{"internalType":"struct ValidReblindStatement","name":"validReblindStatement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"originalSharesNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newPrivateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"}]}]},{"internalType":"struct ValidMatchSettleStatement","name":"matchSettleStatement","type":"tuple","components":[{"internalType":"BN254.ScalarField[]","name":"firstPartyPublicShares","type":"uint256[]"},{"internalType":"BN254.ScalarField[]","name":"secondPartyPublicShares","type":"uint256[]"},{"internalType":"struct OrderSettlementIndices","name":"firstPartySettlementIndices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]},{"internalType":"struct OrderSettlementIndices","name":"secondPartySettlementIndices","type":"tuple","components":[{"internalType":"uint256","name":"balanceSend","type":"uint256"},{"internalType":"uint256","name":"balanceReceive","type":"uint256"},{"internalType":"uint256","name":"order","type":"uint256"}]},{"internalType":"uint256","name":"protocolFeeRate","type":"uint256"}]},{"internalType":"struct MatchProofs","name":"proofs","type":"tuple","components":[{"internalType":"struct PlonkProof","name":"validCommitments0","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validReblind0","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validCommitments1","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validReblind1","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]},{"internalType":"struct PlonkProof","name":"validMatchSettle","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}]},{"internalType":"struct MatchLinkingProofs","name":"linkingProofs","type":"tuple","components":[{"internalType":"struct LinkingProof","name":"validReblindCommitments0","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]},{"internalType":"struct LinkingProof","name":"validCommitmentsMatchSettle0","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]},{"internalType":"struct LinkingProof","name":"validReblindCommitments1","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]},{"internalType":"struct LinkingProof","name":"validCommitmentsMatchSettle1","type":"tuple","components":[{"internalType":"struct BN254.G1Point","name":"linking_quotient_poly_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"linking_poly_opening","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]}]}]}],"stateMutability":"nonpayable","type":"function","name":"processMatchSettle"},{"inputs":[],"stateMutability":"view","type":"function","name":"protocolFeeKey","outputs":[{"internalType":"struct EncryptionKey","name":"","type":"tuple","components":[{"internalType":"struct BabyJubJubPoint","name":"point","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"x","type":"uint256"},{"internalType":"BN254.ScalarField","name":"y","type":"uint256"}]}]}]},{"inputs":[],"stateMutability":"view","type":"function","name":"protocolFeeRate","outputs":[{"internalType":"uint256","name":"","type":"uint256"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"protocolFeeRecipient","outputs":[{"internalType":"address","name":"","type":"address"}]},{"inputs":[{"internalType":"bytes","name":"recipientCommitmentSig","type":"bytes"},{"internalType":"struct ValidFeeRedemptionStatement","name":"statement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"walletRoot","type":"uint256"},{"internalType":"BN254.ScalarField","name":"noteRoot","type":"uint256"},{"internalType":"BN254.ScalarField","name":"walletNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"noteNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newWalletCommitment","type":"uint256"},{"internalType":"BN254.ScalarField[]","name":"newWalletPublicShares","type":"uint256[]"},{"internalType":"struct PublicRootKey","name":"walletRootKey","type":"tuple","components":[{"internalType":"BN254.ScalarField[2]","name":"x","type":"uint256[2]"},{"internalType":"BN254.ScalarField[2]","name":"y","type":"uint256[2]"}]}]},{"internalType":"struct PlonkProof","name":"proof","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}],"stateMutability":"nonpayable","type":"function","name":"redeemFee"},{"inputs":[{"internalType":"BN254.ScalarField","name":"root","type":"uint256"}],"stateMutability":"view","type":"function","name":"rootInHistory","outputs":[{"internalType":"bool","name":"","type":"bool"}]},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256","name":"fee","type":"uint256"}],"stateMutability":"nonpayable","type":"function","name":"setTokenExternalMatchFeeRate"},{"inputs":[{"internalType":"struct ValidOfflineFeeSettlementStatement","name":"statement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"},{"internalType":"BN254.ScalarField","name":"walletNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"updatedWalletCommitment","type":"uint256"},{"internalType":"BN254.ScalarField[]","name":"updatedWalletPublicShares","type":"uint256[]"},{"internalType":"struct ElGamalCiphertext","name":"noteCiphertext","type":"tuple","components":[{"internalType":"struct BabyJubJubPoint","name":"ephemeralKey","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"x","type":"uint256"},{"internalType":"BN254.ScalarField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[]","name":"ciphertext","type":"uint256[]"}]},{"internalType":"BN254.ScalarField","name":"noteCommitment","type":"uint256"},{"internalType":"struct EncryptionKey","name":"protocolKey","type":"tuple","components":[{"internalType":"struct BabyJubJubPoint","name":"point","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"x","type":"uint256"},{"internalType":"BN254.ScalarField","name":"y","type":"uint256"}]}]},{"internalType":"bool","name":"isProtocolFee","type":"bool"}]},{"internalType":"struct PlonkProof","name":"proof","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}],"stateMutability":"payable","type":"function","name":"settleOfflineFee"},{"inputs":[{"internalType":"bytes","name":"newSharesCommitmentSig","type":"bytes"},{"internalType":"struct TransferAuthorization","name":"transferAuthorization","type":"tuple","components":[{"internalType":"uint256","name":"permit2Nonce","type":"uint256"},{"internalType":"uint256","name":"permit2Deadline","type":"uint256"},{"internalType":"bytes","name":"permit2Signature","type":"bytes"},{"internalType":"bytes","name":"externalTransferSignature","type":"bytes"}]},{"internalType":"struct ValidWalletUpdateStatement","name":"statement","type":"tuple","components":[{"internalType":"BN254.ScalarField","name":"previousNullifier","type":"uint256"},{"internalType":"BN254.ScalarField","name":"newPrivateShareCommitment","type":"uint256"},{"internalType":"BN254.ScalarField[]","name":"newPublicShares","type":"uint256[]"},{"internalType":"BN254.ScalarField","name":"merkleRoot","type":"uint256"},{"internalType":"struct ExternalTransfer","name":"externalTransfer","type":"tuple","components":[{"internalType":"address","name":"account","type":"address"},{"internalType":"address","name":"mint","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"enum TransferType","name":"transferType","type":"uint8"}]},{"internalType":"struct PublicRootKey","name":"oldPkRoot","type":"tuple","components":[{"internalType":"BN254.ScalarField[2]","name":"x","type":"uint256[2]"},{"internalType":"BN254.ScalarField[2]","name":"y","type":"uint256[2]"}]}]},{"internalType":"struct PlonkProof","name":"proof","type":"tuple","components":[{"internalType":"struct BN254.G1Point[5]","name":"wire_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"z_comm","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point[5]","name":"quotient_comms","type":"tuple[5]","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"struct BN254.G1Point","name":"w_zeta_omega","type":"tuple","components":[{"internalType":"BN254.BaseField","name":"x","type":"uint256"},{"internalType":"BN254.BaseField","name":"y","type":"uint256"}]},{"internalType":"BN254.ScalarField[5]","name":"wire_evals","type":"uint256[5]"},{"internalType":"BN254.ScalarField[4]","name":"sigma_evals","type":"uint256[4]"},{"internalType":"BN254.ScalarField","name":"z_bar","type":"uint256"}]}],"stateMutability":"nonpayable","type":"function","name":"updateWallet"},{"inputs":[],"stateMutability":"view","type":"function","name":"verifier","outputs":[{"internalType":"contract IVerifier","name":"","type":"address"}]},{"inputs":[],"stateMutability":"view","type":"function","name":"weth","outputs":[{"internalType":"contract IWETH9","name":"","type":"address"}]}],"devdoc":{"kind":"dev","methods":{"createWallet((uint256,uint256[]),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"params":{"proof":"The proof of `VALID WALLET CREATE`","statement":"The statement to verify"}},"getMerkleRoot()":{"returns":{"_0":"The current Merkle root"}},"getProtocolFeeKey()":{"returns":{"_0":"The public encryption key for the protocol's fees"}},"getTokenExternalMatchFeeRate(address)":{"details":"This fee only applies to external matches","params":{"asset":"The asset to get the protocol fee rate for"},"returns":{"_0":"The protocol fee rate for the asset"}},"nullifierSpent(uint256)":{"params":{"nullifier":"The nullifier to check"},"returns":{"_0":"Whether the nullifier has been spent"}},"processAtomicMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"details":"An internal party is one with state committed into the darkpool, whilean external party provides liquidity to the pool during thetransaction in which this method is calledThe receiver of the match settlement is the sender of the transaction","params":{"internalPartyPayload":"The validity proofs for the internal party","linkingProofs":"The proof-linking arguments for the match","matchSettleStatement":"The statement (public inputs) of `VALID MATCH SETTLE`","proofs":"The proofs for the match"}},"processAtomicMatchSettleWithReceiver(address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"details":"The receiver will receive the buy side token amount implied by the matchnet of fees by the relayer and protocol","params":{"internalPartyPayload":"The validity proofs for the internal party","linkingProofs":"The proof-linking arguments for the match","matchSettleStatement":"The statement (public inputs) of `VALID MATCH SETTLE`","proofs":"The proofs for the match","receiver":"The address that will receive the buy side token amount implied by the match"}},"processMalleableAtomicMatchSettle(uint256,address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,(uint256),uint256,uint256,uint8),((uint256),(uint256)),((uint256),(uint256)),uint256[],address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"details":"This is a variant of `processAtomicMatchSettle` that allows the match amount to be determinedafter the proof is generated. This is done by the prover constraining a valid range for the matchamount, allowing the tx sender to choose any value in this range.The darkpool then uses the price specified in the statement to determine the quote amount and feesfor the match, then settles the obligations to both the internal and external parties","params":{"baseAmount":"The base amount of the match, resolving in between the bounds","internalPartyPayload":"The validity proofs for the internal party","linkingProofs":"The proof-linking arguments for the match","matchSettleStatement":"The statement (public inputs) of `VALID MATCH SETTLE`","proofs":"The proofs for the match","receiver":"The address that will receive the buy side token amount for the external party"}},"processMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),(((uint256,uint256,uint256)),(uint256,uint256,uint256)),(uint256[],uint256[],(uint256,uint256,uint256),(uint256,uint256,uint256),uint256),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"params":{"matchSettleStatement":"The statement of `VALID MATCH SETTLE`","party0MatchPayload":"The validity proofs payload for the first party","party1MatchPayload":"The validity proofs payload for the second party","proofs":"The proofs for the match, including two sets of validity proofs and a settlement proof"}},"redeemFee(bytes,(uint256,uint256,uint256,uint256,uint256,uint256[],(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"params":{"proof":"The proof of `VALID FEE REDEMPTION`","statement":"The statement of `VALID FEE REDEMPTION`"}},"rootInHistory(uint256)":{"params":{"root":"The root to check"},"returns":{"_0":"Whether the root is in the history"}},"setTokenExternalMatchFeeRate(address,uint256)":{"details":"of a real number between 0 and 1. To convert to its floating point representation,divide by the fixed point precision, i.e. `fee = assetFeeRate / FIXED_POINT_PRECISION`.","params":{"asset":"The asset to set the protocol fee rate for","fee":"The protocol fee rate to set. This is a fixed point representation"}},"settleOfflineFee((uint256,uint256,uint256,uint256[],((uint256,uint256),uint256[]),uint256,((uint256,uint256)),bool),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"details":"Instead of updating the recipient's wallet, a `Note` is created that the recipient may later redeem","params":{"proof":"The proof of `VALID OFFLINE FEE SETTLEMENT`","statement":"The statement of `VALID OFFLINE FEE SETTLEMENT`"}},"updateWallet(bytes,(uint256,uint256,bytes,bytes),(uint256,uint256,uint256[],uint256,(address,address,uint256,uint8),(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"params":{"newSharesCommitmentSig":"The signature of the new wallet shares commitment by the old wallet's root key","proof":"The proof of `VALID WALLET UPDATE`","statement":"The statement to verify"}}},"version":1},"userdoc":{"kind":"user","methods":{"createWallet((uint256,uint256[]),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"notice":"Create a wallet in the darkpool"},"getMerkleRoot()":{"notice":"Get the current Merkle root"},"getProtocolFeeKey()":{"notice":"Get the public encryption key for the protocol's fees"},"getTokenExternalMatchFeeRate(address)":{"notice":"Get the protocol fee rate for a given asset"},"hasher()":{"notice":"The hasher for the darkpool"},"nullifierSpent(uint256)":{"notice":"Check whether a nullifier has been spent"},"perTokenFeeOverrides(address)":{"notice":"A per-asset fee override for the darkpool"},"permit2()":{"notice":"The Permit2 contract instance for handling deposits"},"processAtomicMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"notice":"Process and atomic match settlement between two parties; one internal and one external"},"processAtomicMatchSettleWithReceiver(address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,uint256,uint256,uint8),(uint256,uint256),uint256[],(uint256,uint256,uint256),uint256,address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"notice":"Process an atomic match with a non-sender receiver specified"},"processMalleableAtomicMatchSettle(uint256,address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,(uint256),uint256,uint256,uint8),((uint256),(uint256)),((uint256),(uint256)),uint256[],address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"notice":"Process a malleable match settlement between two parties"},"processMatchSettle((((uint256,uint256,uint256)),(uint256,uint256,uint256)),(((uint256,uint256,uint256)),(uint256,uint256,uint256)),(uint256[],uint256[],(uint256,uint256,uint256),(uint256,uint256,uint256),uint256),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))))":{"notice":"Settle a match in the darkpool"},"protocolFeeKey()":{"notice":"The public encryption key for the protocol's fees"},"protocolFeeRate()":{"notice":"The protocol fee rate for the darkpool"},"protocolFeeRecipient()":{"notice":"The address at which external parties pay protocol fees"},"redeemFee(bytes,(uint256,uint256,uint256,uint256,uint256,uint256[],(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"notice":"Redeem a fee that has been paid offline into a wallet"},"rootInHistory(uint256)":{"notice":"Check whether a root is in the Merkle root history"},"setTokenExternalMatchFeeRate(address,uint256)":{"notice":"Set the protocol fee rate for a given asset"},"settleOfflineFee((uint256,uint256,uint256,uint256[],((uint256,uint256),uint256[]),uint256,((uint256,uint256)),bool),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"notice":"Settle a fee due to the protocol or a relayer offline, i.e. without updating the recipient's wallet"},"updateWallet(bytes,(uint256,uint256,bytes,bytes),(uint256,uint256,uint256[],uint256,(address,address,uint256,uint8),(uint256[2],uint256[2])),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256))":{"notice":"Update a wallet in the darkpool"},"verifier()":{"notice":"The verifier for the darkpool"},"weth()":{"notice":"The WETH9 contract instance used for depositing/withdrawing native tokens"}},"version":1}},"settings":{"remappings":["@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/","ds-test/=lib/forge-std/lib/ds-test/src/","erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/","forge-gas-snapshot/=lib/permit2/lib/forge-gas-snapshot/src/","forge-std/=lib/forge-std/src/","foundry-huff/=lib/foundry-huff/src/","halmos-cheatcodes/=lib/openzeppelin-contracts/lib/halmos-cheatcodes/src/","openzeppelin-contracts/=lib/openzeppelin-contracts/","oz-contracts/=lib/openzeppelin-contracts/contracts/","permit2-test/=lib/permit2/test/","permit2/=lib/permit2/src/","renegade-lib/=src/libraries/","renegade/=src/","solidity-bn254/=lib/solidity-bn254/src/","solidity-stringutils/=lib/foundry-huff/lib/solidity-stringutils/","solmate/=lib/permit2/lib/solmate/","stringutils/=lib/foundry-huff/lib/solidity-stringutils/"],"optimizer":{"enabled":true,"runs":200},"metadata":{"bytecodeHash":"ipfs"},"compilationTarget":{"src/libraries/interfaces/IDarkpool.sol":"IDarkpool"},"evmVersion":"cancun","libraries":{},"viaIR":true},"sources":{"lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol":{"keccak256":"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7","urls":["bzz-raw://df6f0c459663c9858b6cba2cda1d14a7d05a985bed6d2de72bd8e78c25ee79db","dweb:/ipfs/QmeTTxZ7qVk9rjEv2R4CpCwdf8UMCcRqDNMvzNxHc3Fnn9"],"license":"MIT"},"lib/openzeppelin-contracts/contracts/utils/Panic.sol":{"keccak256":"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a","urls":["bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a","dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG"],"license":"MIT"},"lib/openzeppelin-contracts/contracts/utils/math/Math.sol":{"keccak256":"0xa00be322d7db5786750ce0ac7e2f5b633ac30a5ed5fa1ced1e74acfc19acecea","urls":["bzz-raw://6c84e822f87cbdc4082533b626667b6928715bb2b1e8e7eb96954cebb9e38c8d","dweb:/ipfs/QmZmy9dgxLTerBAQDuuHqbL6EpgRxddqgv5KmwpXYVbKz1"],"license":"MIT"},"lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol":{"keccak256":"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54","urls":["bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8","dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy"],"license":"MIT"},"lib/permit2/src/interfaces/IAllowanceTransfer.sol":{"keccak256":"0x37f0ac203b6ef605c9533e1a739477e8e9dcea90710b40e645a367f8a21ace29","urls":["bzz-raw://e0104d72aeaec1cd66cc232e7de7b7ead08608efcc179491b8a66387614670b0","dweb:/ipfs/QmfAZDyuNC9FXXbnJUwqHNwmAK6uRrXxtWEytLsxjskPsN"],"license":"MIT"},"lib/permit2/src/interfaces/IEIP712.sol":{"keccak256":"0xfdccf2b9639070803cd0e4198427fb0df3cc452ca59bd3b8a0d957a9a4254138","urls":["bzz-raw://f7c936ac42ce89e827db905a1544397f8bdf46db34cdb6aa1b90dea42fdb4c72","dweb:/ipfs/QmVgurxo1N31qZqkPBirw9Z7S9tLYmv6jSwQp8R8ur2cBk"],"license":"MIT"},"lib/permit2/src/interfaces/IPermit2.sol":{"keccak256":"0xaa631cc9f53e699301d94233007110a345e6779011def484e8dd97b8fe0af771","urls":["bzz-raw://fc0502cf19c9c18f320a3001201e89e350393b75837f6b7971de18b2de06f30d","dweb:/ipfs/QmT9SfhdJ7VJNNrf94g4H5usyi7ShqWGx7Cqsz9jZTjX96"],"license":"MIT"},"lib/permit2/src/interfaces/ISignatureTransfer.sol":{"keccak256":"0xe6df9966f8841dc3958ee86169c89de97e7f614c81c28b9dc947b12d732df64e","urls":["bzz-raw://3d4eafdee7f48c3be8350a94eb6edd0bfb2af2c105df65787a77174f356c0317","dweb:/ipfs/QmY1j2adeeAhNpn6cUuthemxGCdLXHTfyMh9yTKsY4mZ2d"],"license":"MIT"},"lib/solidity-bn254/src/BN254.sol":{"keccak256":"0x2ced33c87eb8292d836fbaba94c31951737cc17be2a60f4a866d326b5365551e","urls":["bzz-raw://d9003a3265c76bad130114593623709d0ca2c61c8eab0d9328cda6b4f31f8c6c","dweb:/ipfs/QmV9RR8fTQFYcDUwmCpMndNW9ioc1g9fbNdN9Hn1ySqKWb"],"license":"GPL-3.0-or-later"},"lib/solidity-bn254/src/Utils.sol":{"keccak256":"0x7aa0d7ff8ac27a50f8ceac860c11b17fb103ccd92034c220d040f4a8a9691cbf","urls":["bzz-raw://706e1299d213e627ff62838f63a10813a24335ea4969a7eee9f8854fe35f2d64","dweb:/ipfs/QmVGMSUiub16V2MFcVDQupF1JmhPQ4R83iehqCNLLy3eKG"],"license":"GPL-3.0-or-later"},"src/libraries/darkpool/Constants.sol":{"keccak256":"0x840121ae99751a27befd7265d6969b621f71455e3a05f2bd957e433361bc9b78","urls":["bzz-raw://ff3ff74f7b5a5082680c421cd7c18703ab79fc289203d3483d7faabdd09a237f","dweb:/ipfs/QmRdTmqnKSGJCLZDDN1Bw9qDsbAx5nHgbTc4bUxtLnLpdz"],"license":"MIT"},"src/libraries/darkpool/PublicInputs.sol":{"keccak256":"0x55596285e549f10cdaece9da196c02ca994adccba918e867597985c4c687903f","urls":["bzz-raw://cc4e4fbeab9970b44abea3454d44d9e38c4dbd470af480263a81c9acc289735b","dweb:/ipfs/QmXpUc3K3WtqzmYL8Mbyf3yfWWtkt7iNap2ZBfVxHG5V2Q"],"license":"UNLICENSED"},"src/libraries/darkpool/types/Ciphertext.sol":{"keccak256":"0x79751e669b992c5ee5a3d40658e0be2d33b14326b72a398e63c5a1dfc947e685","urls":["bzz-raw://5fa5469c7601bc80f5523ab3d9855e84164321dd6650c26a6704eb737144b656","dweb:/ipfs/QmSNhFtPwSYZoqyu4EXqUyfuzm8eKYA57sZFrna1VBSjWs"],"license":"UNLICENSED"},"src/libraries/darkpool/types/Fees.sol":{"keccak256":"0x7c04b215697277010ce10e1a2e1608639625b64bbf103167ba98badc88114d7e","urls":["bzz-raw://eb20ac8c1ebc7cbfd0fe18dd447e5b14a988637ef964f897863ce248f9d0bde4","dweb:/ipfs/QmPLtvSNMMeHcWUos3AxpGJstgwASwHMPUsuF19pU6ExDE"],"license":"UNLICENSED"},"src/libraries/darkpool/types/Keychain.sol":{"keccak256":"0xd2e6dd4753e49ef86d0cad42e24f421560dd4b4df23b43b77a9d65b796ffdbe2","urls":["bzz-raw://535085e6f29411e91bd76f91afcc62b9051b264d307c2a5b8e8c95f29d67f24f","dweb:/ipfs/QmTzDSsbxpf6ZiPzmyjiFweABHRWkXYbSWA7zZbRHUdUVZ"],"license":"UNLICENSED"},"src/libraries/darkpool/types/Settlement.sol":{"keccak256":"0x95d58c0d89528101c29337fd26a563c6554a085913b33c26f7f4ed43a549476c","urls":["bzz-raw://5b9efd44f48e7223431d0c3770f360b7c6557f56a9ed418fd77b1d1961ded44f","dweb:/ipfs/QmNtxof8F9duFCv66uHM49WumRie17h3e7qJqWXiMxJe51"],"license":"UNLICENSED"},"src/libraries/darkpool/types/Transfers.sol":{"keccak256":"0x9333ba611417507c6517cc67dd91c552e663a7ce8988e3dd704e0e8102f45071","urls":["bzz-raw://e60081668353bd2f6fc9a40178a718ae88fffd730ad6ef0a6647117351764d38","dweb:/ipfs/QmXB1E8UYMHsWkvYiswCnBhYkCLaGUqsqVL7xaVopCUHNB"],"license":"UNLICENSED"},"src/libraries/darkpool/types/TypesLib.sol":{"keccak256":"0x68887b160040cd0929b3db18f90d44838ade4380d51ee660524690cf136decf2","urls":["bzz-raw://0e80a166c85b9fd3d3dc8bd9bddb54221b766211c801ce021d6c6eabd79e1c5a","dweb:/ipfs/QmdzqaQBrLW6C4qvKakKGUHPj3EzfUg15nucZc6VyrE1SW"],"license":"UNLICENSED"},"src/libraries/darkpool/types/Wallet.sol":{"keccak256":"0xaf0eaba75e6c68b6368e346a90767cd58b77dfb94a4a1e7366b8c33cd0cddb63","urls":["bzz-raw://3b0c5fee21af2ff5c5721461c7133edcb09173c696c476b4a7165025f10bc485","dweb:/ipfs/QmTcotbrAc7fEGi25dJGeP3wYmX3THciikcQeRn3CUoF1C"],"license":"UNLICENSED"},"src/libraries/interfaces/IDarkpool.sol":{"keccak256":"0x4eb753e30b4b9aa62b748317df5f04cf53217e704ff0f0d455f8986c16209451","urls":["bzz-raw://a30e383a4d5dbbc8c5f7fe8ef2c7085096d30073524336f3e9f0f0713b0b785f","dweb:/ipfs/QmT1FjhJbZEsi4Cbsjg3AAngjHgpVWWuVaNoBy7yQpbxBK"],"license":"MIT"},"src/libraries/interfaces/IHasher.sol":{"keccak256":"0x398864a227ae6435a6a466c8e9469def8cf9d91de1ae6a638c97f512576a34c5","urls":["bzz-raw://244515ebe78503113a482e261cf8ef8d3b7d4be80369dbaec92c58dd4c866309","dweb:/ipfs/QmV1NuXKe3VVjL5HoaRwZQtPmSMNssxe3APyN7beM5pGJh"],"license":"UNLICENSED"},"src/libraries/interfaces/IVerifier.sol":{"keccak256":"0xfabb9f913ab4a3a4a9150b6c1675368c038babc3dc725f4d9867d90b146c7cdc","urls":["bzz-raw://782b2c3c84deba435b8ddaa871b3a6221a1a78ff4c7ad238defc1a21347d262f","dweb:/ipfs/QmUupqL6Cfb69KhvYWt6jGnRLz55KUpkmC1nTiRRFWyWKV"],"license":"UNLICENSED"},"src/libraries/interfaces/IWETH9.sol":{"keccak256":"0x05a109500d93a34a4046bd644c19017362795352656d123eb3bf5ce26c7a26c6","urls":["bzz-raw://bcc3d5f2251ce33455959caf39fc19209b7a355916c47378bd4e7f4b0ee31f35","dweb:/ipfs/QmaS2K29tTQbF3zWNses6KCuwqQUStwQJ8JMcsHJUi5RkF"],"license":"MIT"},"src/libraries/verifier/BN254Helpers.sol":{"keccak256":"0xde01afe43d75609756857d8681a9af9b8c2e96d05c59408a4f3b369676b190b5","urls":["bzz-raw://2ed17530e325ba109e73b25ec3d177ead9dea2fff4b48c680522c1d41531a623","dweb:/ipfs/QmaCeDDWs2HFN8evWjaWmGF7DHcbMvFxowxwiyyBD3amzy"],"license":"Apache-2.0"},"src/libraries/verifier/Types.sol":{"keccak256":"0x35403540cf17679654c73b32e58afab852fba06118896f1c1b216ea984444210","urls":["bzz-raw://86458d287395956c743f514b8671b4e83929abedcc772e7ff7172c9b1accf3dc","dweb:/ipfs/Qme5WC3HRQrkJqjqWwnYThtpcYdp1RHxAhH9RrwWNhbTPd"],"license":"Apache-2.0"}},"version":1},"id":60}
+[
+  {
+    "type": "function",
+    "name": "createWallet",
+    "inputs": [
+      {
+        "name": "statement",
+        "type": "tuple",
+        "internalType": "struct ValidWalletCreateStatement",
+        "components": [
+          {
+            "name": "walletShareCommitment",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "publicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct PlonkProof",
+        "components": [
+          {
+            "name": "wire_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "z_comm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "quotient_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta_omega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire_evals",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "sigma_evals",
+            "type": "uint256[4]",
+            "internalType": "BN254.ScalarField[4]"
+          },
+          {
+            "name": "z_bar",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getMerkleRoot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProtocolFeeKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct EncryptionKey",
+        "components": [
+          {
+            "name": "point",
+            "type": "tuple",
+            "internalType": "struct BabyJubJubPoint",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTokenExternalMatchFeeRate",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasher",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IHasher"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nullifierSpent",
+    "inputs": [
+      {
+        "name": "nullifier",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "perTokenFeeOverrides",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permit2",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IPermit2"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "processAtomicMatchSettle",
+    "inputs": [
+      {
+        "name": "internalPartyPayload",
+        "type": "tuple",
+        "internalType": "struct PartyMatchPayload",
+        "components": [
+          {
+            "name": "validCommitmentsStatement",
+            "type": "tuple",
+            "internalType": "struct ValidCommitmentsStatement",
+            "components": [
+              {
+                "name": "indices",
+                "type": "tuple",
+                "internalType": "struct OrderSettlementIndices",
+                "components": [
+                  {
+                    "name": "balanceSend",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "balanceReceive",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "order",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validReblindStatement",
+            "type": "tuple",
+            "internalType": "struct ValidReblindStatement",
+            "components": [
+              {
+                "name": "originalSharesNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newPrivateShareCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "merkleRoot",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "matchSettleStatement",
+        "type": "tuple",
+        "internalType": "struct ValidMatchSettleAtomicStatement",
+        "components": [
+          {
+            "name": "matchResult",
+            "type": "tuple",
+            "internalType": "struct ExternalMatchResult",
+            "components": [
+              {
+                "name": "quoteMint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "baseMint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quoteAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "baseAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "direction",
+                "type": "uint8",
+                "internalType": "enum ExternalMatchDirection"
+              }
+            ]
+          },
+          {
+            "name": "externalPartyFees",
+            "type": "tuple",
+            "internalType": "struct FeeTake",
+            "components": [
+              {
+                "name": "relayerFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "protocolFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "internalPartyModifiedShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "internalPartySettlementIndices",
+            "type": "tuple",
+            "internalType": "struct OrderSettlementIndices",
+            "components": [
+              {
+                "name": "balanceSend",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "balanceReceive",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "order",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "relayerFeeAddress",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "proofs",
+        "type": "tuple",
+        "internalType": "struct MatchAtomicProofs",
+        "components": [
+          {
+            "name": "validCommitments",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validReblind",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validMatchSettleAtomic",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "linkingProofs",
+        "type": "tuple",
+        "internalType": "struct MatchAtomicLinkingProofs",
+        "components": [
+          {
+            "name": "validReblindCommitments",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validCommitmentsMatchSettleAtomic",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "processAtomicMatchSettleWithReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "internalPartyPayload",
+        "type": "tuple",
+        "internalType": "struct PartyMatchPayload",
+        "components": [
+          {
+            "name": "validCommitmentsStatement",
+            "type": "tuple",
+            "internalType": "struct ValidCommitmentsStatement",
+            "components": [
+              {
+                "name": "indices",
+                "type": "tuple",
+                "internalType": "struct OrderSettlementIndices",
+                "components": [
+                  {
+                    "name": "balanceSend",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "balanceReceive",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "order",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validReblindStatement",
+            "type": "tuple",
+            "internalType": "struct ValidReblindStatement",
+            "components": [
+              {
+                "name": "originalSharesNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newPrivateShareCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "merkleRoot",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "matchSettleStatement",
+        "type": "tuple",
+        "internalType": "struct ValidMatchSettleAtomicStatement",
+        "components": [
+          {
+            "name": "matchResult",
+            "type": "tuple",
+            "internalType": "struct ExternalMatchResult",
+            "components": [
+              {
+                "name": "quoteMint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "baseMint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quoteAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "baseAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "direction",
+                "type": "uint8",
+                "internalType": "enum ExternalMatchDirection"
+              }
+            ]
+          },
+          {
+            "name": "externalPartyFees",
+            "type": "tuple",
+            "internalType": "struct FeeTake",
+            "components": [
+              {
+                "name": "relayerFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "protocolFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "internalPartyModifiedShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "internalPartySettlementIndices",
+            "type": "tuple",
+            "internalType": "struct OrderSettlementIndices",
+            "components": [
+              {
+                "name": "balanceSend",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "balanceReceive",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "order",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "relayerFeeAddress",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "proofs",
+        "type": "tuple",
+        "internalType": "struct MatchAtomicProofs",
+        "components": [
+          {
+            "name": "validCommitments",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validReblind",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validMatchSettleAtomic",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "linkingProofs",
+        "type": "tuple",
+        "internalType": "struct MatchAtomicLinkingProofs",
+        "components": [
+          {
+            "name": "validReblindCommitments",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validCommitmentsMatchSettleAtomic",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "processMalleableAtomicMatchSettle",
+    "inputs": [
+      {
+        "name": "baseAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "internalPartyPayload",
+        "type": "tuple",
+        "internalType": "struct PartyMatchPayload",
+        "components": [
+          {
+            "name": "validCommitmentsStatement",
+            "type": "tuple",
+            "internalType": "struct ValidCommitmentsStatement",
+            "components": [
+              {
+                "name": "indices",
+                "type": "tuple",
+                "internalType": "struct OrderSettlementIndices",
+                "components": [
+                  {
+                    "name": "balanceSend",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "balanceReceive",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "order",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validReblindStatement",
+            "type": "tuple",
+            "internalType": "struct ValidReblindStatement",
+            "components": [
+              {
+                "name": "originalSharesNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newPrivateShareCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "merkleRoot",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "matchSettleStatement",
+        "type": "tuple",
+        "internalType": "struct ValidMalleableMatchSettleAtomicStatement",
+        "components": [
+          {
+            "name": "matchResult",
+            "type": "tuple",
+            "internalType": "struct BoundedMatchResult",
+            "components": [
+              {
+                "name": "quoteMint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "baseMint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "price",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "minBaseAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxBaseAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "direction",
+                "type": "uint8",
+                "internalType": "enum ExternalMatchDirection"
+              }
+            ]
+          },
+          {
+            "name": "externalFeeRates",
+            "type": "tuple",
+            "internalType": "struct FeeTakeRate",
+            "components": [
+              {
+                "name": "relayerFeeRate",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "protocolFeeRate",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "internalFeeRates",
+            "type": "tuple",
+            "internalType": "struct FeeTakeRate",
+            "components": [
+              {
+                "name": "relayerFeeRate",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "protocolFeeRate",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "internalPartyPublicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "relayerFeeAddress",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      },
+      {
+        "name": "proofs",
+        "type": "tuple",
+        "internalType": "struct MalleableMatchAtomicProofs",
+        "components": [
+          {
+            "name": "validCommitments",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validReblind",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validMalleableMatchSettleAtomic",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "linkingProofs",
+        "type": "tuple",
+        "internalType": "struct MatchAtomicLinkingProofs",
+        "components": [
+          {
+            "name": "validReblindCommitments",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validCommitmentsMatchSettleAtomic",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "processMatchSettle",
+    "inputs": [
+      {
+        "name": "party0MatchPayload",
+        "type": "tuple",
+        "internalType": "struct PartyMatchPayload",
+        "components": [
+          {
+            "name": "validCommitmentsStatement",
+            "type": "tuple",
+            "internalType": "struct ValidCommitmentsStatement",
+            "components": [
+              {
+                "name": "indices",
+                "type": "tuple",
+                "internalType": "struct OrderSettlementIndices",
+                "components": [
+                  {
+                    "name": "balanceSend",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "balanceReceive",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "order",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validReblindStatement",
+            "type": "tuple",
+            "internalType": "struct ValidReblindStatement",
+            "components": [
+              {
+                "name": "originalSharesNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newPrivateShareCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "merkleRoot",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "party1MatchPayload",
+        "type": "tuple",
+        "internalType": "struct PartyMatchPayload",
+        "components": [
+          {
+            "name": "validCommitmentsStatement",
+            "type": "tuple",
+            "internalType": "struct ValidCommitmentsStatement",
+            "components": [
+              {
+                "name": "indices",
+                "type": "tuple",
+                "internalType": "struct OrderSettlementIndices",
+                "components": [
+                  {
+                    "name": "balanceSend",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "balanceReceive",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "order",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validReblindStatement",
+            "type": "tuple",
+            "internalType": "struct ValidReblindStatement",
+            "components": [
+              {
+                "name": "originalSharesNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newPrivateShareCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "merkleRoot",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "matchSettleStatement",
+        "type": "tuple",
+        "internalType": "struct ValidMatchSettleStatement",
+        "components": [
+          {
+            "name": "firstPartyPublicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "secondPartyPublicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "firstPartySettlementIndices",
+            "type": "tuple",
+            "internalType": "struct OrderSettlementIndices",
+            "components": [
+              {
+                "name": "balanceSend",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "balanceReceive",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "order",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "secondPartySettlementIndices",
+            "type": "tuple",
+            "internalType": "struct OrderSettlementIndices",
+            "components": [
+              {
+                "name": "balanceSend",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "balanceReceive",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "order",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "proofs",
+        "type": "tuple",
+        "internalType": "struct MatchProofs",
+        "components": [
+          {
+            "name": "validCommitments0",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validReblind0",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validCommitments1",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validReblind1",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validMatchSettle",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wire_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "z_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotient_comms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "w_zeta_omega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wire_evals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigma_evals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "z_bar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "linkingProofs",
+        "type": "tuple",
+        "internalType": "struct MatchLinkingProofs",
+        "components": [
+          {
+            "name": "validReblindCommitments0",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validCommitmentsMatchSettle0",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validReblindCommitments1",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "validCommitmentsMatchSettle1",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linking_quotient_poly_comm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linking_poly_opening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct EncryptionKey",
+        "components": [
+          {
+            "name": "point",
+            "type": "tuple",
+            "internalType": "struct BabyJubJubPoint",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeRate",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "redeemFee",
+    "inputs": [
+      {
+        "name": "recipientCommitmentSig",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "statement",
+        "type": "tuple",
+        "internalType": "struct ValidFeeRedemptionStatement",
+        "components": [
+          {
+            "name": "walletRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "noteRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "walletNullifier",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "noteNullifier",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "newSharesCommitment",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "newWalletPublicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "walletRootKey",
+            "type": "tuple",
+            "internalType": "struct PublicRootKey",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256[2]",
+                "internalType": "BN254.ScalarField[2]"
+              },
+              {
+                "name": "y",
+                "type": "uint256[2]",
+                "internalType": "BN254.ScalarField[2]"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct PlonkProof",
+        "components": [
+          {
+            "name": "wire_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "z_comm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "quotient_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta_omega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire_evals",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "sigma_evals",
+            "type": "uint256[4]",
+            "internalType": "BN254.ScalarField[4]"
+          },
+          {
+            "name": "z_bar",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rootInHistory",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "uint256",
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setTokenExternalMatchFeeRate",
+    "inputs": [
+      {
+        "name": "asset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "fee",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleOfflineFee",
+    "inputs": [
+      {
+        "name": "statement",
+        "type": "tuple",
+        "internalType": "struct ValidOfflineFeeSettlementStatement",
+        "components": [
+          {
+            "name": "merkleRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "walletNullifier",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "newWalletCommitment",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "updatedWalletPublicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "noteCiphertext",
+            "type": "tuple",
+            "internalType": "struct ElGamalCiphertext",
+            "components": [
+              {
+                "name": "ephemeralKey",
+                "type": "tuple",
+                "internalType": "struct BabyJubJubPoint",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "ciphertext",
+                "type": "uint256[]",
+                "internalType": "BN254.ScalarField[]"
+              }
+            ]
+          },
+          {
+            "name": "noteCommitment",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "protocolKey",
+            "type": "tuple",
+            "internalType": "struct EncryptionKey",
+            "components": [
+              {
+                "name": "point",
+                "type": "tuple",
+                "internalType": "struct BabyJubJubPoint",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "isProtocolFee",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct PlonkProof",
+        "components": [
+          {
+            "name": "wire_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "z_comm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "quotient_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta_omega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire_evals",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "sigma_evals",
+            "type": "uint256[4]",
+            "internalType": "BN254.ScalarField[4]"
+          },
+          {
+            "name": "z_bar",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "updateWallet",
+    "inputs": [
+      {
+        "name": "newSharesCommitmentSig",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "transferAuthorization",
+        "type": "tuple",
+        "internalType": "struct TransferAuthorization",
+        "components": [
+          {
+            "name": "permit2Nonce",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "permit2Deadline",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "permit2Signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "externalTransferSignature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "statement",
+        "type": "tuple",
+        "internalType": "struct ValidWalletUpdateStatement",
+        "components": [
+          {
+            "name": "previousNullifier",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "newWalletCommitment",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "newPublicShares",
+            "type": "uint256[]",
+            "internalType": "BN254.ScalarField[]"
+          },
+          {
+            "name": "merkleRoot",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "externalTransfer",
+            "type": "tuple",
+            "internalType": "struct ExternalTransfer",
+            "components": [
+              {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "mint",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "amount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "transferType",
+                "type": "uint8",
+                "internalType": "enum TransferType"
+              }
+            ]
+          },
+          {
+            "name": "oldPkRoot",
+            "type": "tuple",
+            "internalType": "struct PublicRootKey",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256[2]",
+                "internalType": "BN254.ScalarField[2]"
+              },
+              {
+                "name": "y",
+                "type": "uint256[2]",
+                "internalType": "BN254.ScalarField[2]"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct PlonkProof",
+        "components": [
+          {
+            "name": "wire_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "z_comm",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "quotient_comms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "w_zeta_omega",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "wire_evals",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "sigma_evals",
+            "type": "uint256[4]",
+            "internalType": "BN254.ScalarField[4]"
+          },
+          {
+            "name": "z_bar",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "verifier",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IVerifier"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "weth",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IWETH9"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "MerkleInsertion",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint128",
+        "indexed": true,
+        "internalType": "uint128"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MerkleOpeningNode",
+    "inputs": [
+      {
+        "name": "depth",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "index",
+        "type": "uint128",
+        "indexed": true,
+        "internalType": "uint128"
+      },
+      {
+        "name": "new_value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WalletUpdated",
+    "inputs": [
+      {
+        "name": "wallet_blinder_share",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/integration/src/contracts/darkpool.rs
+++ b/integration/src/contracts/darkpool.rs
@@ -25,7 +25,7 @@ impl Darkpool {
         let root_u256 = scalar_to_u256(root);
         let call = self.rootInHistory(root_u256);
         let res = call_helper(call).await?;
-        Ok(res._0)
+        Ok(res)
     }
 }
 

--- a/integration/src/contracts/type_conversion.rs
+++ b/integration/src/contracts/type_conversion.rs
@@ -45,7 +45,7 @@ use super::darkpool::{
 impl From<SizedValidWalletCreateStatement> for ContractValidWalletCreateStatement {
     fn from(statement: SizedValidWalletCreateStatement) -> Self {
         Self {
-            privateShareCommitment: scalar_to_u256(statement.private_shares_commitment),
+            walletShareCommitment: scalar_to_u256(statement.wallet_share_commitment),
             publicShares: statement
                 .public_wallet_shares
                 .to_scalars()
@@ -61,7 +61,7 @@ impl From<SizedValidWalletUpdateStatement> for ContractValidWalletUpdateStatemen
     fn from(statement: SizedValidWalletUpdateStatement) -> Self {
         Self {
             previousNullifier: scalar_to_u256(statement.old_shares_nullifier),
-            newPrivateShareCommitment: scalar_to_u256(statement.new_private_shares_commitment),
+            newWalletCommitment: scalar_to_u256(statement.new_wallet_commitment),
             newPublicShares: statement
                 .new_public_shares
                 .to_scalars()

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -44,9 +44,9 @@ const DEFAULT_PKEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae
 /// The provider type for the tests
 pub type Wallet = DynProvider<Ethereum>;
 /// A darkpool instance using the default generics
-pub type Darkpool = IDarkpoolInstance<(), Wallet, Ethereum>;
+pub type Darkpool = IDarkpoolInstance<Wallet, Ethereum>;
 /// An ERC20 instance with default generics
-pub type ERC20 = ERC20MockInstance<(), Wallet, Ethereum>;
+pub type ERC20 = ERC20MockInstance<Wallet, Ethereum>;
 
 /// The CLI arguments for the integration tests
 #[derive(Debug, Clone, Parser)]

--- a/integration/src/tests/create_wallet.rs
+++ b/integration/src/tests/create_wallet.rs
@@ -72,7 +72,7 @@ pub fn create_sized_witness_statement_with_wallet(
     SizedValidWalletCreateWitness,
     SizedValidWalletCreateStatement,
 ) {
-    let private_shares_commitment = wallet.get_private_share_commitment();
+    let wallet_share_commitment = wallet.get_wallet_share_commitment();
 
     (
         SizedValidWalletCreateWitness {
@@ -80,7 +80,7 @@ pub fn create_sized_witness_statement_with_wallet(
             blinder_seed,
         },
         SizedValidWalletCreateStatement {
-            private_shares_commitment,
+            wallet_share_commitment,
             public_wallet_shares: wallet.blinded_public_shares.clone(),
         },
     )

--- a/integration/src/tests/match_settle.rs
+++ b/integration/src/tests/match_settle.rs
@@ -76,7 +76,7 @@ async fn test_match_settle(args: TestArgs) -> Result<(), eyre::Error> {
     fund_wallet_for_match(&match_result, &o2, &mut wallet2, &args).await?;
 
     // Generate calldata and submit the match
-    let protocol_fee_rate = call_helper(darkpool.protocolFeeRate()).await?._0;
+    let protocol_fee_rate = call_helper(darkpool.protocolFeeRate()).await?;
     let fee_rate = FixedPoint::from_repr(u256_to_scalar(protocol_fee_rate));
     let (
         party0_payload,

--- a/integration/src/tests/update_wallet.rs
+++ b/integration/src/tests/update_wallet.rs
@@ -300,7 +300,7 @@ fn build_witness_statement(
     let old_wallet_nullifier = old_wallet.get_wallet_nullifier();
     let old_wallet_merkle = old_wallet.merkle_proof.expect("no merkle proof").clone();
     let old_wallet_merkle_root = old_wallet_merkle.compute_root();
-    let new_wallet_commitment = new_wallet.get_private_share_commitment();
+    let new_wallet_commitment = new_wallet.get_wallet_share_commitment();
     let merkle_proof = old_wallet_merkle.into();
 
     Ok((
@@ -313,7 +313,7 @@ fn build_witness_statement(
         },
         SizedValidWalletUpdateStatement {
             old_shares_nullifier: old_wallet_nullifier,
-            new_private_shares_commitment: new_wallet_commitment,
+            new_wallet_commitment,
             new_public_shares: new_wallet.blinded_public_shares,
             merkle_root: old_wallet_merkle_root,
             external_transfer: transfer,

--- a/integration/src/util/transactions.rs
+++ b/integration/src/util/transactions.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 use test_helpers::assert_eq_result;
 
 /// The call builder type for the tests
-pub type TestCallBuilder<'a, C> = CallBuilder<(), &'a DynProvider, C, Ethereum>;
+pub type TestCallBuilder<'a, C> = CallBuilder<&'a DynProvider, C, Ethereum>;
 
 // ----------------
 // | Transactions |

--- a/src/libraries/darkpool/PublicInputs.sol
+++ b/src/libraries/darkpool/PublicInputs.sol
@@ -18,8 +18,8 @@ import { ElGamalCiphertext, EncryptionKey } from "./types/Ciphertext.sol";
 /// @title ValidWalletCreateStatement
 /// @notice The statement type for the `VALID WALLET CREATE` proof
 struct ValidWalletCreateStatement {
-    /// @dev The commitment to the wallet's private shares
-    BN254.ScalarField privateShareCommitment;
+    /// @dev The commitment to the wallet's secret shares
+    BN254.ScalarField walletShareCommitment;
     /// @dev The public wallet shares of the wallet
     BN254.ScalarField[] publicShares;
 }
@@ -29,8 +29,8 @@ struct ValidWalletCreateStatement {
 struct ValidWalletUpdateStatement {
     /// @dev The nullifier of the previous wallet
     BN254.ScalarField previousNullifier;
-    /// @dev A commitment to the new wallet's private shares
-    BN254.ScalarField newPrivateShareCommitment;
+    /// @dev A commitment to the new wallet's secret shares
+    BN254.ScalarField newWalletCommitment;
     /// @dev The new public shares of the wallet
     BN254.ScalarField[] newPublicShares;
     /// @dev The global Merkle root that the old wallet shares open into
@@ -119,8 +119,8 @@ struct ValidOfflineFeeSettlementStatement {
     BN254.ScalarField merkleRoot;
     /// @dev The nullifier of the wallet paying the fee
     BN254.ScalarField walletNullifier;
-    /// @dev The commitment to the payer's updated private shares
-    BN254.ScalarField updatedWalletCommitment;
+    /// @dev The commitment to the payer's updated wallet shares
+    BN254.ScalarField newWalletCommitment;
     /// @dev The public shares of the payer's updated wallet
     BN254.ScalarField[] updatedWalletPublicShares;
     /// @dev The ciphertext of the note
@@ -144,8 +144,8 @@ struct ValidFeeRedemptionStatement {
     BN254.ScalarField walletNullifier;
     /// @dev The nullifier of the note
     BN254.ScalarField noteNullifier;
-    /// @dev A commitment to the new wallet's private shares
-    BN254.ScalarField newWalletCommitment;
+    /// @dev A commitment to the new wallet's secret shares
+    BN254.ScalarField newSharesCommitment;
     /// @dev The new public shares of the wallet
     BN254.ScalarField[] newWalletPublicShares;
     /// @dev The root key for the keychain of the wallet that redeems the note
@@ -210,7 +210,7 @@ library StatementSerializer {
         BN254.ScalarField[] memory serialized = new BN254.ScalarField[](VALID_WALLET_CREATE_SCALAR_SIZE);
 
         // Add the wallet commitment
-        serialized[0] = self.privateShareCommitment;
+        serialized[0] = self.walletShareCommitment;
 
         // Add all public shares
         for (uint256 i = 0; i < self.publicShares.length; i++) {
@@ -232,7 +232,7 @@ library StatementSerializer {
     {
         BN254.ScalarField[] memory serialized = new BN254.ScalarField[](VALID_WALLET_UPDATE_SCALAR_SIZE);
         serialized[0] = self.previousNullifier;
-        serialized[1] = self.newPrivateShareCommitment;
+        serialized[1] = self.newWalletCommitment;
 
         // Copy the public shares
         uint256 n = self.newPublicShares.length;
@@ -432,7 +432,7 @@ library StatementSerializer {
         BN254.ScalarField[] memory serialized = new BN254.ScalarField[](VALID_OFFLINE_FEE_SETTLEMENT_SCALAR_SIZE);
         serialized[0] = self.merkleRoot;
         serialized[1] = self.walletNullifier;
-        serialized[2] = self.updatedWalletCommitment;
+        serialized[2] = self.newWalletCommitment;
 
         // Serialize the updated wallet public shares
         uint256 offset = 3;
@@ -479,7 +479,7 @@ library StatementSerializer {
         serialized[1] = self.noteRoot;
         serialized[2] = self.walletNullifier;
         serialized[3] = self.noteNullifier;
-        serialized[4] = self.newWalletCommitment;
+        serialized[4] = self.newSharesCommitment;
 
         // Serialize the new wallet public shares
         uint256 offset = 5;

--- a/test/darkpool/RedeemFee.t.sol
+++ b/test/darkpool/RedeemFee.t.sol
@@ -24,7 +24,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory newSharesCommitmentSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot, receiverWallet);
         darkpool.redeemFee(newSharesCommitmentSig, statement, proof);
 
         // Check that the nullifiers are spent
@@ -42,7 +42,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory newSharesCommitmentSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot, receiverWallet);
 
         // Should fail
         vm.expectRevert("Verification failed for fee redemption");
@@ -60,7 +60,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
         Vm.Wallet memory receiverWallet = randomEthereumWallet();
         BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
         (bytes memory redeemSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot, receiverWallet);
         statement.newWalletPublicShares[statement.newWalletPublicShares.length - 1] = publicBlinder;
 
         // Should fail
@@ -76,7 +76,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory newSharesCommitmentSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot, receiverWallet);
         statement.walletRoot = randomScalar();
         vm.expectRevert(INVALID_ROOT_REVERT_STRING);
         darkpool.redeemFee(newSharesCommitmentSig, statement, proof);
@@ -90,7 +90,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory newSharesCommitmentSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot, receiverWallet);
         statement.noteRoot = randomScalar();
         vm.expectRevert(INVALID_NOTE_ROOT_REVERT_STRING);
         darkpool.redeemFee(newSharesCommitmentSig, statement, proof);
@@ -103,7 +103,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Update a wallet using the nullifier
         (bytes memory updateSig, ValidWalletUpdateStatement memory updateStatement, PlonkProof memory updateProof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
         updateStatement.previousNullifier = nullifier;
         updateStatement.merkleRoot = merkleRoot;
@@ -115,7 +115,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory redeemSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot2, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot2, receiverWallet);
         statement.walletNullifier = nullifier;
         vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
         darkpool.redeemFee(redeemSig, statement, proof);
@@ -128,7 +128,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Update a wallet using the nullifier
         (bytes memory updateSig, ValidWalletUpdateStatement memory updateStatement, PlonkProof memory updateProof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
         updateStatement.previousNullifier = nullifier;
         updateStatement.merkleRoot = merkleRoot;
@@ -140,7 +140,7 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory redeemSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot2, receiverWallet, hasher);
+            redeemFeeCalldata(merkleRoot2, receiverWallet);
         statement.noteNullifier = nullifier;
         vm.expectRevert(INVALID_NULLIFIER_REVERT_STRING);
         darkpool.redeemFee(redeemSig, statement, proof);
@@ -154,8 +154,8 @@ contract RedeemFeeTest is DarkpoolTestBase {
 
         // Generate the calldata and redeem the fee
         (bytes memory redeemSig, ValidFeeRedemptionStatement memory statement, PlonkProof memory proof) =
-            redeemFeeCalldata(merkleRoot, receiverWallet, hasher);
-        statement.newWalletCommitment = randomScalar();
+            redeemFeeCalldata(merkleRoot, receiverWallet);
+        statement.newSharesCommitment = randomScalar();
         statement.walletRootKey = forgeWalletToRootKey(receiverWallet);
         vm.expectRevert(INVALID_SIGNATURE_REVERT_STRING);
         darkpool.redeemFee(redeemSig, statement, proof);

--- a/test/darkpool/SettleAtomicMatch.t.sol
+++ b/test/darkpool/SettleAtomicMatch.t.sol
@@ -518,7 +518,7 @@ contract SettleAtomicMatchTest is DarkpoolTestBase {
 
         // Update a wallet using the nullifier
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         statement.previousNullifier = nullifier;
         statement.merkleRoot = merkleRoot;
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();

--- a/test/darkpool/SettleMalleableAtomicMatch.t.sol
+++ b/test/darkpool/SettleMalleableAtomicMatch.t.sol
@@ -220,7 +220,7 @@ contract SettleMalleableAtomicMatch is DarkpoolTestBase {
             bytes memory newSharesCommitmentSig,
             ValidWalletUpdateStatement memory updateStatement,
             PlonkProof memory updateProof
-        ) = updateWalletCalldata(hasher);
+        ) = updateWalletCalldata();
         updateStatement.previousNullifier = nullifier;
         updateStatement.merkleRoot = merkleRoot;
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();

--- a/test/darkpool/SettleMatch.t.sol
+++ b/test/darkpool/SettleMatch.t.sol
@@ -94,7 +94,7 @@ contract SettleMatchTest is DarkpoolTestBase {
 
         // Update a wallet using the nullifier
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         statement.previousNullifier = nullifier;
         statement.merkleRoot = merkleRoot;
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();

--- a/test/darkpool/SettleOfflineFee.t.sol
+++ b/test/darkpool/SettleOfflineFee.t.sol
@@ -88,7 +88,7 @@ contract SettleOfflineFee is DarkpoolTestBase {
             bytes memory newSharesCommitmentSig,
             ValidWalletUpdateStatement memory updateStatement,
             PlonkProof memory updateProof
-        ) = updateWalletCalldata(hasher);
+        ) = updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
         updateStatement.previousNullifier = nullifier;
         updateStatement.merkleRoot = merkleRoot;

--- a/test/darkpool/UpdateWallet.t.sol
+++ b/test/darkpool/UpdateWallet.t.sol
@@ -16,7 +16,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
     function test_updateWallet_validUpdate() public {
         // Setup calldata
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Modify the merkle root to be valid
@@ -51,7 +51,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
             transferType: TransferType.Deposit
         });
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            generateUpdateWalletCalldata(hasher, transfer, rootKeyWallet);
+            generateUpdateWalletCalldata(transfer, rootKeyWallet);
         statement.merkleRoot = darkpool.getMerkleRoot();
 
         // Authorize the deposit
@@ -88,7 +88,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
             transferType: TransferType.Withdrawal
         });
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            generateUpdateWalletCalldata(hasher, transfer, rootKeyWallet);
+            generateUpdateWalletCalldata(transfer, rootKeyWallet);
         statement.merkleRoot = darkpool.getMerkleRoot();
 
         // Authorize the withdrawal
@@ -109,7 +109,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
     /// @notice Test updating a wallet with an invalid proof
     function test_updateWallet_invalidProof() public {
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         vm.expectRevert("Verification failed for wallet update");
@@ -125,7 +125,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
 
         // Update the wallet with the same public blinder share
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
         statement.merkleRoot = darkpool.getMerkleRoot();
         statement.newPublicShares[statement.newPublicShares.length - 1] = publicBlinder;
@@ -139,7 +139,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
     function test_updateWallet_invalidMerkleRoot() public {
         // Setup calldata
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Modify the merkle root to be invalid
@@ -154,7 +154,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
     function test_updateWallet_spentNullifier() public {
         // Setup calldata
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Modify the merkle root to be valid
@@ -173,7 +173,7 @@ contract UpdateWalletTest is DarkpoolTestBase {
     function test_updateWallet_invalidSignature() public {
         // Setup calldata
         (bytes memory newSharesCommitmentSig, ValidWalletUpdateStatement memory statement, PlonkProof memory proof) =
-            updateWalletCalldata(hasher);
+            updateWalletCalldata();
         TransferAuthorization memory transferAuthorization = emptyTransferAuthorization();
 
         // Use the current Merkle root to isolate the signature check directly


### PR DESCRIPTION
### Purpose
This PR updates all darkpool methods to expect full wallet commitments in their interface.

I also updated all unit and integration tests.

### Todo
- Update match methods

### Testing
- [x] All unit tests pass
- [x] All integration tests pass