### PR TITLE
Darkpool: Add `processAtomicMatchSettleWithCommitments` method

### DIFF
--- a/src/libraries/interfaces/IDarkpool.sol
+++ b/src/libraries/interfaces/IDarkpool.sol
@@ -15,6 +15,7 @@ import {
     ValidMatchSettleStatement,
     ValidMatchSettleWithCommitmentsStatement,
     ValidMatchSettleAtomicStatement,
+    ValidMatchSettleAtomicWithCommitmentsStatement,
     ValidMalleableMatchSettleAtomicStatement,
     ValidOfflineFeeSettlementStatement,
     ValidFeeRedemptionStatement
@@ -172,6 +173,24 @@ interface IDarkpool {
     function processAtomicMatchSettle(
         PartyMatchPayload calldata internalPartyPayload,
         ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        payable;
+
+    /// @notice Process an atomic match settlement between two parties with commitments; one internal and one external
+    /// @dev An internal party is one with state committed into the darkpool, while
+    /// @dev an external party provides liquidity to the pool during the
+    /// @dev transaction in which this method is called
+    /// @dev The receiver of the match settlement is the sender of the transaction
+    /// @param internalPartyPayload The validity proofs for the internal party
+    /// @param matchSettleStatement The statement (public inputs) of `VALID MATCH SETTLE WITH COMMITMENTS`
+    /// @param proofs The proofs for the match
+    /// @param linkingProofs The proof-linking arguments for the match
+    function processAtomicMatchSettleWithCommitments(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicWithCommitmentsStatement calldata matchSettleStatement,
         MatchAtomicProofs calldata proofs,
         MatchAtomicLinkingProofs calldata linkingProofs
     )

--- a/src/libraries/interfaces/IVerifier.sol
+++ b/src/libraries/interfaces/IVerifier.sol
@@ -8,6 +8,7 @@ import {
     ValidMatchSettleStatement,
     ValidMatchSettleWithCommitmentsStatement,
     ValidMatchSettleAtomicStatement,
+    ValidMatchSettleAtomicWithCommitmentsStatement,
     ValidMalleableMatchSettleAtomicStatement,
     ValidOfflineFeeSettlementStatement,
     ValidFeeRedemptionStatement
@@ -69,7 +70,7 @@ interface IVerifier {
     /// @param matchSettleStatement The statement of `VALID MATCH SETTLE WITH COMMITMENTS`
     /// @param proofs The proofs for the match, including two sets of validity proofs and a settlement proof
     /// @return True if the match bundle is valid, false otherwise
-    function verifyMatchSettleWithCommitments(
+    function verifyMatchBundleWithCommitments(
         PartyMatchPayload calldata party0MatchPayload,
         PartyMatchPayload calldata party1MatchPayload,
         ValidMatchSettleWithCommitmentsStatement calldata matchSettleStatement,
@@ -89,6 +90,22 @@ interface IVerifier {
     function verifyAtomicMatchBundle(
         PartyMatchPayload calldata internalPartyPayload,
         ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `VALID MATCH SETTLE ATOMIC WITH COMMITMENTS`
+    /// @param internalPartyPayload The payload for the internal party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE ATOMIC WITH COMMITMENTS`
+    /// @param proofs The proofs for the match, including a validity proof and a settlement proof
+    /// @param linkingProofs The proof linking arguments for the match
+    /// @return True if the proof is valid, false otherwise
+    function verifyAtomicMatchBundleWithCommitments(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicWithCommitmentsStatement calldata matchSettleStatement,
         MatchAtomicProofs calldata proofs,
         MatchAtomicLinkingProofs calldata linkingProofs
     )

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -53,6 +53,7 @@ contract DarkpoolTestBase is CalldataUtils {
     bytes constant INVALID_ETH_DEPOSIT_AMOUNT_REVERT_STRING = "msg.value does not match deposit amount";
     bytes constant INVALID_INTERNAL_PARTY_FEE_REVERT_STRING = "Invalid internal party protocol fee rate";
     bytes constant INVALID_EXTERNAL_PARTY_FEE_REVERT_STRING = "Invalid external party protocol fee rate";
+    bytes constant INVALID_PRIVATE_COMMITMENT_REVERT_STRING = "Invalid internal party private share commitment";
 
     function setUp() public virtual {
         // Deploy a Permit2 instance for testing

--- a/test/test-contracts/TestVerifier.sol
+++ b/test/test-contracts/TestVerifier.sol
@@ -6,8 +6,9 @@ import {
     ValidWalletCreateStatement,
     ValidWalletUpdateStatement,
     ValidMatchSettleStatement,
-    ValidMatchSettleAtomicStatement,
     ValidMatchSettleWithCommitmentsStatement,
+    ValidMatchSettleAtomicStatement,
+    ValidMatchSettleAtomicWithCommitmentsStatement,
     ValidMalleableMatchSettleAtomicStatement,
     ValidOfflineFeeSettlementStatement,
     ValidFeeRedemptionStatement,
@@ -96,7 +97,7 @@ contract TestVerifier is IVerifier {
     /// @param proofs The proofs for the match, including two sets of validity proofs and a settlement proof
     /// @param linkingProofs The proof linking arguments for the match
     /// @return True always, regardless of the proof
-    function verifyMatchSettleWithCommitments(
+    function verifyMatchBundleWithCommitments(
         PartyMatchPayload calldata party0MatchPayload,
         PartyMatchPayload calldata party1MatchPayload,
         ValidMatchSettleWithCommitmentsStatement calldata matchSettleStatement,
@@ -107,7 +108,7 @@ contract TestVerifier is IVerifier {
         view
         returns (bool)
     {
-        verifier.verifyMatchSettleWithCommitments(
+        verifier.verifyMatchBundleWithCommitments(
             party0MatchPayload, party1MatchPayload, matchSettleStatement, proofs, linkingProofs
         );
         return true;
@@ -130,6 +131,28 @@ contract TestVerifier is IVerifier {
         returns (bool)
     {
         verifier.verifyAtomicMatchBundle(internalPartyPayload, matchSettleStatement, proofs, linkingProofs);
+        return true;
+    }
+
+    /// @notice Verify a proof of `VALID MATCH SETTLE ATOMIC WITH COMMITMENTS`
+    /// @param internalPartyPayload The payload for the internal party
+    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE ATOMIC WITH COMMITMENTS`
+    /// @param proofs The proofs for the match, including a validity proof and a settlement proof
+    /// @param linkingProofs The proof linking arguments for the match
+    /// @return True always, regardless of the proof
+    function verifyAtomicMatchBundleWithCommitments(
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicWithCommitmentsStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        view
+        returns (bool)
+    {
+        verifier.verifyAtomicMatchBundleWithCommitments(
+            internalPartyPayload, matchSettleStatement, proofs, linkingProofs
+        );
         return true;
     }
 

--- a/test/utils/CalldataUtils.sol
+++ b/test/utils/CalldataUtils.sol
@@ -38,6 +38,7 @@ import {
     ValidMatchSettleStatement,
     ValidMatchSettleWithCommitmentsStatement,
     ValidMatchSettleAtomicStatement,
+    ValidMatchSettleAtomicWithCommitmentsStatement,
     ValidMalleableMatchSettleAtomicStatement,
     ValidOfflineFeeSettlementStatement,
     ValidFeeRedemptionStatement
@@ -266,6 +267,41 @@ contract CalldataUtils is TestUtils {
         linkingProofs = MatchAtomicLinkingProofs({
             validReblindCommitments: dummyLinkingProof(),
             validCommitmentsMatchSettleAtomic: dummyLinkingProof()
+        });
+    }
+
+    /// --- Settle Atomic Match With Commitments --- ///
+
+    /// @notice Generate calldata for settling an atomic match with commitments
+    function settleAtomicMatchWithCommitmentsCalldata(
+        BN254.ScalarField merkleRoot,
+        ExternalMatchResult memory matchResult
+    )
+        internal
+        returns (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMatchSettleAtomicWithCommitmentsStatement memory statement,
+            MatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        )
+    {
+        // Generate base calldata
+        ValidMatchSettleAtomicStatement memory baseStatement;
+        (internalPartyPayload, baseStatement, proofs, linkingProofs) =
+            settleAtomicMatchCalldataWithMatchResult(merkleRoot, matchResult);
+
+        // Create a `VALID MATCH SETTLE ATOMIC WITH COMMITMENTS` statement
+        BN254.ScalarField privateShareCommitment = internalPartyPayload.validReblindStatement.newPrivateShareCommitment;
+        BN254.ScalarField newShareCommitment = randomScalar();
+        statement = ValidMatchSettleAtomicWithCommitmentsStatement({
+            privateShareCommitment: privateShareCommitment,
+            newShareCommitment: newShareCommitment,
+            matchResult: baseStatement.matchResult,
+            externalPartyFees: baseStatement.externalPartyFees,
+            internalPartyModifiedShares: baseStatement.internalPartyModifiedShares,
+            internalPartySettlementIndices: baseStatement.internalPartySettlementIndices,
+            protocolFeeRate: baseStatement.protocolFeeRate,
+            relayerFeeAddress: baseStatement.relayerFeeAddress
         });
     }
 


### PR DESCRIPTION
### Purpose
This PR adds a `processAtomicMatchSettleWithCommitments` method to the darkpool.

### Testing
- [x] All unit tests pass
- [x] All integration tests pass