### PR TITLE
libraries: darkpool: ExternalTransfers.sol: Use correct weth interface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/permit2"]
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2
+[submodule "lib/solmate"]
+	path = lib/solmate
+	url = https://github.com/transmissions11/solmate

--- a/remappings.txt
+++ b/remappings.txt
@@ -7,5 +7,6 @@ solidity-bn254/=lib/solidity-bn254/src/
 permit2/=lib/permit2/src/
 permit2-test/=lib/permit2/test/
 oz-contracts/=lib/openzeppelin-contracts/contracts
+solmate/=lib/solmate/src
 renegade/=src
 renegade-lib/=src/libraries

--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -133,6 +133,9 @@ contract Darkpool is Ownable2Step, Pausable {
         merkleTree.initialize();
     }
 
+    /// @notice Allows the contract to receive ETH transfers
+    receive() external payable { }
+
     // --- State Getters --- //
 
     /// @notice Get the current Merkle root

--- a/src/libraries/darkpool/ExternalTransfers.sol
+++ b/src/libraries/darkpool/ExternalTransfers.sol
@@ -17,6 +17,7 @@ import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
 import { IERC20 } from "oz-contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "oz-contracts/token/ERC20/utils/SafeERC20.sol";
+import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
 
 /// @title ExternalTransferLib
 /// @notice This library implements the logic for executing external transfers
@@ -187,7 +188,8 @@ library ExternalTransferLib {
     function executeSimpleWithdrawal(SimpleTransfer memory transfer, IWETH9 wrapper) internal {
         // Handle native token withdrawals by unwrapping the transfer amount into ETH
         if (DarkpoolConstants.isNativeToken(transfer.mint)) {
-            wrapper.withdrawTo(transfer.account, transfer.amount);
+            wrapper.withdraw(transfer.amount);
+            SafeTransferLib.safeTransferETH(transfer.account, transfer.amount);
             return;
         }
 

--- a/src/libraries/interfaces/IWETH9.sol
+++ b/src/libraries/interfaces/IWETH9.sol
@@ -9,5 +9,5 @@ interface IWETH9 is IERC20 {
     function deposit() external payable;
 
     /// @notice Withdraw (burn) WETH and receive ETH
-    function withdrawTo(address, uint256) external;
+    function withdraw(uint256) external;
 }

--- a/test/test-contracts/WethMock.sol
+++ b/test/test-contracts/WethMock.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
 
 /// @title WethMock
 /// @notice A mock implementation of the IWETH9 interface
@@ -13,8 +14,8 @@ contract WethMock is IWETH9, ERC20Mock {
     }
 
     /// @notice Withdraw ETH from the contract
-    function withdrawTo(address to, uint256 amount) external {
+    function withdraw(uint256 amount) external {
         _burn(msg.sender, amount);
-        payable(to).transfer(amount);
+        SafeTransferLib.safeTransferETH(msg.sender, amount);
     }
 }


### PR DESCRIPTION
### Purpose
This PR changes the `IWETH.sol` interface used in the darkpool to use the correct [base WETH9](https://basescan.org/address/0x4200000000000000000000000000000000000006#writeContract) ABI. In specific, this has a `withdraw` method where the Arbitrum implementation uses a `withdrawTo`. So we must manually transfer ETH to the receiver after withdrawing from the wrapper contract.

### Testing
- [x] All tests pass