### PR TITLE
script: DeployDummyErc20.sol: Add mock ERC20 script

### DIFF
--- a/script/DeployDev.s.sol
+++ b/script/DeployDev.s.sol
@@ -8,7 +8,7 @@ import "permit2-test/utils/DeployPermit2.sol";
 import "./utils/DeployUtils.sol";
 import "renegade-lib/interfaces/IWETH9.sol";
 import "../test/test-contracts/WethMock.sol";
-import "oz-contracts/mocks/token/ERC20Mock.sol";
+import "solmate/test/utils/mocks/MockERC20.sol";
 
 contract DeployDevScript is Script {
     function run() public {
@@ -21,15 +21,16 @@ contract DeployDevScript is Script {
         console.log("Permit2 deployed at:", address(permit2));
 
         // Deploy two mock ERC20s
-        ERC20Mock quoteToken = new ERC20Mock();
-        ERC20Mock baseToken = new ERC20Mock();
+        MockERC20 quoteToken = new MockERC20("Quote Token", "QT", 18);
+        MockERC20 baseToken = new MockERC20("Base Token", "BT", 18);
         console.log("Quote Token deployed at:", address(quoteToken));
         console.log("Base Token deployed at:", address(baseToken));
         DeployUtils.writeDeployment(vm, "QuoteToken", address(quoteToken));
         DeployUtils.writeDeployment(vm, "BaseToken", address(baseToken));
 
         // Deploy WETH Mock
-        IWETH9 weth = IWETH9(new WethMock());
+        WethMock wethMock = new WethMock();
+        IWETH9 weth = IWETH9(address(wethMock));
         vm.deal(address(weth), 1e32);
         console.log("WETH Mock deployed at:", address(weth));
         DeployUtils.writeDeployment(vm, "Weth", address(weth));

--- a/script/DeployDummyErc20.sol
+++ b/script/DeployDummyErc20.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "forge-std/Script.sol";
 import "forge-std/console.sol";
 import "solmate/test/utils/mocks/MockERC20.sol";
+import "../test/test-contracts/WethMock.sol";
 
 /**
  * @title DeployDummyERC20Script
@@ -21,11 +22,28 @@ contract DeployDummyERC20Script is Script {
         vm.startBroadcast();
 
         // Create the token with constructor params for name, symbol, and decimals
+        // Then mint initial supply to the deployer
         MockERC20 token = new MockERC20(name, symbol, decimals);
-
-        // Mint initial supply to the deployer
         token.mint(msg.sender, _INITIAL_SUPPLY);
         console.log("MockERC20 deployed at: %s", address(token));
+
+        vm.stopBroadcast();
+    }
+}
+
+/**
+ * @title DeployWethMockScript
+ * @notice Deploy script for the WethMock token
+ * @dev Usage: forge script script/DeployDummyErc20.sol --rpc-url <your_rpc_url> --broadcast --sig "deployWeth()"
+ */
+contract DeployWethMockScript is Script {
+    function deployWeth() public {
+        console.log("Deploying WethMock");
+        vm.startBroadcast();
+
+        // Deploy WethMock
+        WethMock weth = new WethMock();
+        console.log("WethMock deployed at: %s", address(weth));
 
         vm.stopBroadcast();
     }

--- a/script/DeployDummyErc20.sol
+++ b/script/DeployDummyErc20.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import "solmate/test/utils/mocks/MockERC20.sol";
+
+/**
+ * @title DeployDummyERC20Script
+ * @notice Deploy script for the MockERC20 token from solmate
+ * @dev Usage: forge script script/DeployDummyErc20.sol --rpc-url <your_rpc_url> --broadcast --sig
+ * "run(string,string,uint8)" "TokenName" "TKN" 18
+ */
+contract DeployDummyERC20Script is Script {
+    // Hardcoded initial supply: 1 token with decimal correction
+    uint256 private constant _INITIAL_SUPPLY = 10 ** 18;
+
+    function run(string memory name, string memory symbol, uint8 decimals) public {
+        console.log("Deploying MockERC20 with name: %s, symbol: %s, decimals: %d", name, symbol, decimals);
+
+        vm.startBroadcast();
+
+        // Create the token with constructor params for name, symbol, and decimals
+        MockERC20 token = new MockERC20(name, symbol, decimals);
+
+        // Mint initial supply to the deployer
+        token.mint(msg.sender, _INITIAL_SUPPLY);
+        console.log("MockERC20 deployed at: %s", address(token));
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/darkpool/DarkpoolTestBase.sol
+++ b/test/darkpool/DarkpoolTestBase.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
 import { WethMock } from "../test-contracts/WethMock.sol";
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { IPermit2 } from "permit2/interfaces/IPermit2.sol";
 import { DeployPermit2 } from "permit2-test/utils/DeployPermit2.sol";
 import { Test } from "forge-std/Test.sol";
@@ -87,7 +88,7 @@ contract DarkpoolTestBase is CalldataUtils {
             TEST_PROTOCOL_FEE,
             protocolFeeAddr,
             protocolFeeKey,
-            weth,
+            IWETH9(address(weth)),
             hasher,
             verifier,
             permit2,
@@ -99,7 +100,7 @@ contract DarkpoolTestBase is CalldataUtils {
             TEST_PROTOCOL_FEE,
             protocolFeeAddr,
             protocolFeeKey,
-            weth,
+            IWETH9(address(weth)),
             hasher,
             realVerifier,
             permit2,

--- a/test/test-contracts/WethMock.sol
+++ b/test/test-contracts/WethMock.sol
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
-import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
 
 /// @title WethMock
-/// @notice A mock implementation of the IWETH9 interface
-contract WethMock is IWETH9, ERC20Mock {
+/// @notice A mock implementation of WETH9
+contract WethMock is MockERC20 {
+    constructor() MockERC20("Wrapped Ether", "WETH", 18) { }
+
     /// @notice Deposit ETH into the contract
     function deposit() external payable {
-        _mint(msg.sender, msg.value);
+        mint(msg.sender, msg.value);
     }
 
     /// @notice Withdraw ETH from the contract
     function withdraw(uint256 amount) external {
-        _burn(msg.sender, amount);
+        burn(msg.sender, amount);
         SafeTransferLib.safeTransferETH(msg.sender, amount);
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds a script for deploying dummy erc20 tokens (including WETH). It allows the ticker, name, and decimals to be configured.

### Testing
- [x] Deployed a standard ERC20 and a WETH mock to arbitrum sepolia