### PR TITLE
tools: deploy: Specify owner and fee decryption key

### DIFF
--- a/tools/tool-utils/Cargo.toml
+++ b/tools/tool-utils/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 description = "Common utilities for Renegade tools"
 
 [dependencies]
+alloy = "1.0.1"
 eyre = "0.6"

--- a/tools/tool-utils/src/lib.rs
+++ b/tools/tool-utils/src/lib.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::Address;
 use eyre::{eyre, Result};
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
@@ -90,7 +91,5 @@ pub fn prompt_for_eth_address(prompt: &str) -> Result<String> {
 /// Function to validate an Ethereum address format
 /// This is a simple check for the 0x prefix and length
 pub fn is_valid_eth_address_format(address: &str) -> bool {
-    address.len() == 42
-        && address.starts_with("0x")
-        && address[2..].chars().all(|c| c.is_ascii_hexdigit())
+    Address::from_str(address).is_ok()
 }


### PR DESCRIPTION
### Purpose
This PR allows the owner and fee decryption key to be specified by the deploy CLI and will prompt the user for missing values here. This also catches up the deploy tool to the latest ABI of the Solidity deploy script -- in particular adding the `owner` argument.

### Testing
- [x] Deployed contracts to testnet using updated script