### PR TITLE
Darkpool.sol: Accept `quoteAmount` in malleable matches

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -428,7 +428,9 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         MatchProofs calldata proofs,
         MatchLinkingProofs calldata linkingProofs
     )
-        public
+        /// We mark this method as internal as it's not currently used in the system, so we save
+        /// on bytecode size for the Darkpool contract by allowing the optimizer to prune it
+        internal
         whenNotPaused
     {
         ValidCommitmentsStatement calldata commitmentsStatement0 = party0MatchPayload.validCommitmentsStatement;
@@ -591,8 +593,10 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         MatchAtomicProofs calldata proofs,
         MatchAtomicLinkingProofs calldata linkingProofs
     )
-        public
-        payable
+        /// We mark this method as internal as it's not currently used in the system, so we save
+        /// on bytecode size for the Darkpool contract by allowing the optimizer to prune it
+        internal
+        /// payable // TODO: Uncomment this if we mark this method public
         whenNotPaused
     {
         ValidCommitmentsStatement calldata commitmentsStatement = internalPartyPayload.validCommitmentsStatement;
@@ -670,6 +674,7 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
     /// @dev amount, allowing the tx sender to choose any value in this range.
     /// @dev The darkpool then uses the price specified in the statement to determine the quote amount and fees
     /// @dev for the match, then settles the obligations to both the internal and external parties
+    /// @param quoteAmount The quote amount of the match, resolving in between the bounds
     /// @param baseAmount The base amount of the match, resolving in between the bounds
     /// @param receiver The address that will receive the buy side token amount for the external party
     /// @param internalPartyPayload The validity proofs for the internal party
@@ -678,6 +683,7 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
     /// @param linkingProofs The proof-linking arguments for the match
     /// @return The amount of the external party's receive amount
     function processMalleableAtomicMatchSettle(
+        uint256 quoteAmount,
         uint256 baseAmount,
         address receiver,
         PartyMatchPayload calldata internalPartyPayload,
@@ -721,7 +727,8 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         require(externalPartyFees.protocolFeeRate.repr == protocolFee, "Invalid external party protocol fee rate");
 
         // 4. Build an external match result from the bounded match result
-        ExternalMatchResult memory matchResult = TypesLib.buildExternalMatchResult(baseAmount, boundedMatchResult);
+        ExternalMatchResult memory matchResult =
+            TypesLib.buildExternalMatchResult(quoteAmount, baseAmount, boundedMatchResult);
 
         // 5. Compute the fees due on the match
         (, uint256 externalPartyReceiveAmount) = matchResult.externalPartyBuyMintAmount();

--- a/src/libraries/interfaces/IDarkpool.sol
+++ b/src/libraries/interfaces/IDarkpool.sol
@@ -217,42 +217,6 @@ interface IDarkpool {
     )
         external;
 
-    /// @notice Process a match settlement between two parties with commitments
-    /// @param party0MatchPayload The validity proofs payload for the first party
-    /// @param party1MatchPayload The validity proofs payload for the second party
-    /// @param matchSettleStatement The statement of `VALID MATCH SETTLE WITH COMMITMENTS`
-    /// @param proofs The proofs for the match
-    /// @param linkingProofs The proof-linking arguments for the match
-    function processMatchSettleWithCommitments(
-        PartyMatchPayload calldata party0MatchPayload,
-        PartyMatchPayload calldata party1MatchPayload,
-        ValidMatchSettleWithCommitmentsStatement calldata matchSettleStatement,
-        MatchProofs calldata proofs,
-        MatchLinkingProofs calldata linkingProofs
-    )
-        external;
-
-    /// @notice Process an atomic match settlement between two parties with commitments; one internal and one external
-    /// @dev An internal party is one with state committed into the darkpool, while
-    /// @dev an external party provides liquidity to the pool during the
-    /// @dev transaction in which this method is called
-    /// @dev The receiver of the match settlement is the sender of the transaction
-    /// @dev This variant allows the receiver to be specified as a parameter
-    /// @param receiver The address that will receive the buy side token amount for the external party
-    /// @param internalPartyPayload The validity proofs for the internal party
-    /// @param matchSettleStatement The statement (public inputs) of `VALID MATCH SETTLE WITH COMMITMENTS`
-    /// @param proofs The proofs for the match
-    /// @param linkingProofs The proof-linking arguments for the match
-    function processAtomicMatchSettleWithCommitments(
-        address receiver,
-        PartyMatchPayload calldata internalPartyPayload,
-        ValidMatchSettleAtomicWithCommitmentsStatement calldata matchSettleStatement,
-        MatchAtomicProofs calldata proofs,
-        MatchAtomicLinkingProofs calldata linkingProofs
-    )
-        external
-        payable;
-
     /// @notice Process an atomic match with a non-sender receiver specified
     /// @dev The receiver will receive the buy side token amount implied by the match
     /// @dev net of fees by the relayer and protocol
@@ -279,6 +243,7 @@ interface IDarkpool {
     /// @dev amount, allowing the tx sender to choose any value in this range.
     /// @dev The darkpool then uses the price specified in the statement to determine the quote amount and fees
     /// @dev for the match, then settles the obligations to both the internal and external parties
+    /// @param quoteAmount The quote amount of the match, resolving in between the bounds
     /// @param baseAmount The base amount of the match, resolving in between the bounds
     /// @param receiver The address that will receive the buy side token amount for the external party
     /// @param internalPartyPayload The validity proofs for the internal party
@@ -287,6 +252,7 @@ interface IDarkpool {
     /// @param linkingProofs The proof-linking arguments for the match
     /// @return The amount of the buy token that the external party receives
     function processMalleableAtomicMatchSettle(
+        uint256 quoteAmount,
         uint256 baseAmount,
         address receiver,
         PartyMatchPayload calldata internalPartyPayload,


### PR DESCRIPTION
### Purpose
This PR replicates the changes of [this PR](https://github.com/renegade-fi/renegade-contracts/pull/334) into the solidity implementation. Specifically, we accept a quote amount in the malleable match path and constrain its bounds via the base bounds.

### Todo
- Update gas sponsor
- Update tests