### PR TITLE
Darkpool.sol: Add `setVerifier` method to upgrade verifier

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -265,6 +265,13 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         transferExecutor = newTransferExecutor;
     }
 
+    /// @notice Set the verifier for the darkpool
+    /// @param newVerifier The new verifier for the darkpool
+    function setVerifier(IVerifier newVerifier) public onlyOwner {
+        require(address(newVerifier) != address(0), "Address cannot be zero");
+        verifier = newVerifier;
+    }
+
     /// @notice Pause the darkpool
     function pause() public onlyOwner {
         _pause();


### PR DESCRIPTION
### Purpose
This PR adds a `setVerifier` method, which will set the address of the verifier contract.

### Testing
- [ ] Test on Base sepolia contracts.