### PR TITLE
Darkpool.sol: Resolve receiver address if not specified

### DIFF
--- a/src/Darkpool.sol
+++ b/src/Darkpool.sol
@@ -565,10 +565,11 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         );
 
         // 6. Execute external transfers to/from the external party using TransferExecutor
+        address resolvedReceiver = receiver == address(0) ? msg.sender : receiver;
         (bool success, bytes memory returnData) = transferExecutor.delegatecall(
             abi.encodeWithSelector(
                 TransferExecutor.executeAtomicMatchTransfers.selector,
-                receiver,
+                resolvedReceiver,
                 matchSettleStatement.relayerFeeAddress,
                 protocolFeeRecipient,
                 matchResult,
@@ -661,10 +662,11 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         );
 
         // 6. Execute external transfers to/from the external party using TransferExecutor
+        address resolvedReceiver = receiver == address(0) ? msg.sender : receiver;
         (bool success, bytes memory returnData) = transferExecutor.delegatecall(
             abi.encodeWithSelector(
                 TransferExecutor.executeAtomicMatchTransfers.selector,
-                receiver,
+                resolvedReceiver,
                 matchSettleStatement.relayerFeeAddress,
                 protocolFeeRecipient,
                 matchResult,
@@ -761,10 +763,11 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         );
 
         // 8. Execute external transfers to/from the external party using TransferExecutor
+        address resolvedReceiver = receiver == address(0) ? msg.sender : receiver;
         (bool success, bytes memory returnData) = transferExecutor.delegatecall(
             abi.encodeWithSelector(
                 TransferExecutor.executeAtomicMatchTransfers.selector,
-                receiver,
+                resolvedReceiver,
                 matchSettleStatement.relayerFeeAddress,
                 protocolFeeRecipient,
                 matchResult,


### PR DESCRIPTION
### Purpose
This PR changes the atomic settlement methods to use `msg.sender` in the case that the specified receiver address is `address(0)`. This removes the need for clients to specify the address directly in the case that they wish to use `msg.sender`.

### Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Testing in testnet