### PR TITLE
uniswapx_executor: Add initial implemenation

### DIFF
--- a/src/proxies/UniswapXExecutorProxy.sol
+++ b/src/proxies/UniswapXExecutorProxy.sol
@@ -17,19 +17,19 @@ contract UniswapXExecutorProxy is TransparentUpgradeableProxy {
      * @param implementation The UniswapXExecutor implementation address
      * @param admin The admin address - serves as both ProxyAdmin owner and UniswapXExecutor owner
      * @param darkpool The darkpool address
-     * @param whitelistedCaller The whitelisted caller address
+     * @param uniswapXReactor The UniswapX reactor address
      */
     constructor(
         address implementation,
         address admin,
         address darkpool,
-        address whitelistedCaller
+        address uniswapXReactor
     )
         payable
         TransparentUpgradeableProxy(
             implementation,
             admin,
-            abi.encodeWithSelector(IUniswapXExecutor.initialize.selector, admin, darkpool, whitelistedCaller)
+            abi.encodeWithSelector(IUniswapXExecutor.initialize.selector, admin, darkpool, uniswapXReactor)
         )
     { }
 }

--- a/src/uniswapx_executor/DarkpoolExecutor.sol
+++ b/src/uniswapx_executor/DarkpoolExecutor.sol
@@ -8,6 +8,19 @@ import { Initializable } from "oz-contracts/proxy/utils/Initializable.sol";
 import { Ownable } from "oz-contracts/access/Ownable.sol";
 import { Ownable2Step } from "oz-contracts/access/Ownable2Step.sol";
 import { Pausable } from "oz-contracts/utils/Pausable.sol";
+import { IDarkpool } from "renegade-lib/interfaces/IDarkpool.sol";
+import { IReactor } from "uniswapx/interfaces/IReactor.sol";
+import { SignedOrder } from "uniswapx/base/ReactorStructs.sol";
+import {
+    PartyMatchPayload,
+    MatchAtomicProofs,
+    MatchAtomicLinkingProofs,
+    MalleableMatchAtomicProofs
+} from "renegade-lib/darkpool/types/Settlement.sol";
+import {
+    ValidMatchSettleAtomicStatement,
+    ValidMalleableMatchSettleAtomicStatement
+} from "renegade-lib/darkpool/PublicInputs.sol";
 
 /**
  * @title DarkpoolExecutor
@@ -19,10 +32,14 @@ contract DarkpoolExecutor is IReactorCallback, Initializable, Ownable2Step, Paus
     // --- State Variables --- //
 
     /// @notice The darkpool contract
-    address public darkpool;
-    /// @notice The whitelisted caller
-    /// @dev Practically this is the UniswapX order reactor
-    address public whitelistedCaller;
+    IDarkpool public darkpool;
+    /// @notice The UniswapX reactor contract
+    IReactor public uniswapXReactor;
+
+    // --- Errors --- //
+
+    /// @notice Thrown when the caller is not whitelisted
+    error UnauthorizedCaller();
 
     // --- Initializer --- //
 
@@ -32,19 +49,105 @@ contract DarkpoolExecutor is IReactorCallback, Initializable, Ownable2Step, Paus
     }
 
     /// @notice Initializes the contract
-    function initialize(address initialOwner, address darkpool_, address whitelistedCaller_) public initializer {
+    function initialize(address initialOwner, address darkpool_, address uniswapXReactor_) public initializer {
         _transferOwnership(initialOwner);
-        darkpool = darkpool_;
-        whitelistedCaller = whitelistedCaller_;
+        darkpool = IDarkpool(darkpool_);
+        uniswapXReactor = IReactor(uniswapXReactor_);
+    }
+
+    // --- Order Execution --- //
+
+    /// @notice Execute a UniswapX order with atomic match settlement
+    /// @param order The signed order to execute
+    /// @param internalPartyPayload The validity proofs for the internal party
+    /// @param matchSettleStatement The statement (public inputs) of VALID MATCH SETTLE
+    /// @param proofs The proofs for the match
+    /// @param linkingProofs The proof-linking arguments for the match
+    function executeAtomicMatchSettle(
+        SignedOrder calldata order,
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMatchSettleAtomicStatement calldata matchSettleStatement,
+        MatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        payable
+        whenNotPaused
+    {
+        // Encode callback data for processAtomicMatchSettle
+        bytes memory callbackData = abi.encodeWithSelector(
+            darkpool.processAtomicMatchSettle.selector,
+            address(uniswapXReactor), // receiver is always the reactor
+            internalPartyPayload,
+            matchSettleStatement,
+            proofs,
+            linkingProofs
+        );
+
+        // Call the reactor's executeWithCallback, which will call back to our reactorCallback
+        uniswapXReactor.executeWithCallback{ value: msg.value }(order, callbackData);
+    }
+
+    /// @notice Execute a UniswapX order with malleable atomic match settlement
+    /// @param order The signed order to execute
+    /// @param quoteAmount The quote amount of the match, resolving in between the bounds
+    /// @param baseAmount The base amount of the match, resolving in between the bounds
+    /// @param internalPartyPayload The validity proofs for the internal party
+    /// @param matchSettleStatement The statement (public inputs) of VALID MATCH SETTLE
+    /// @param proofs The proofs for the match
+    /// @param linkingProofs The proof-linking arguments for the match
+    function executeMalleableAtomicMatchSettle(
+        SignedOrder calldata order,
+        uint256 quoteAmount,
+        uint256 baseAmount,
+        PartyMatchPayload calldata internalPartyPayload,
+        ValidMalleableMatchSettleAtomicStatement calldata matchSettleStatement,
+        MalleableMatchAtomicProofs calldata proofs,
+        MatchAtomicLinkingProofs calldata linkingProofs
+    )
+        external
+        payable
+        whenNotPaused
+    {
+        // Encode callback data for processMalleableAtomicMatchSettle
+        bytes memory callbackData = abi.encodeWithSelector(
+            darkpool.processMalleableAtomicMatchSettle.selector,
+            quoteAmount,
+            baseAmount,
+            address(uniswapXReactor), // receiver is always the reactor
+            internalPartyPayload,
+            matchSettleStatement,
+            proofs,
+            linkingProofs
+        );
+
+        // Call the reactor's executeWithCallback, which will call back to our reactorCallback
+        uniswapXReactor.executeWithCallback{ value: msg.value }(order, callbackData);
     }
 
     // --- Callback Logic --- //
 
     /// @notice Called by the reactor during the execution of an order
-    /// @param resolvedOrders Has inputs and outputs
     /// @param callbackData The callbackData specified for an order execution
     /// @dev Must have approved each token and amount in outputs to the msg.sender
-    function reactorCallback(ResolvedOrder[] memory resolvedOrders, bytes memory callbackData) external override {
-        // TODO: Implement the callback logic
+    function reactorCallback(
+        ResolvedOrder[] memory, /* resolvedOrders */
+        bytes memory callbackData
+    )
+        external
+        override
+        whenNotPaused
+    {
+        // Only the reactor may call this function
+        if (msg.sender != address(uniswapXReactor)) revert UnauthorizedCaller();
+
+        // Any ether balance present in the contract is meant as input to the darkpool trade
+        // TODO: Properly account for the ether value of the transaction
+        uint256 value = address(this).balance;
+
+        // Forward the call directly to the darkpool
+        // The callback data already contains the selector and all properly encoded parameters
+        (bool success,) = address(darkpool).call{ value: value }(callbackData);
+        require(success, "Darkpool call failed");
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds an initial implementation of the Darkpool wrapper UniswapX executor contract. This contract receives a `SignedOrder` and either an atomic match bundle or a malleable match bundle (through `executeAtomicMatchSettle` and `executeMalleableAtomicMatchSettle` respectively). It then calls the reactor which will:
1. Transfer the input tokens of the trade to the executor via permit2
2. Call the `reactorCallback` method on `msg.sender` (our executor) to fill the trade. Note that by the end of this callback the reactor expects to hold the receive tokens directly -- i.e. an allowance back to the reactor is not enough. For this reason we set the atomic match receiver to be the reactor.
3. Transfer the output tokens back to the order initiator.

### Todo
- Add testing in a follow up
- Fix any bugs that come up while testing

### Testing
- [x] Tested with simple tests locally
- [x] Existing and new unit tests pass